### PR TITLE
Fix App Store sandbox entitlement for embedded Python helper

### DIFF
--- a/scripts/sh/build_appstore_release.sh
+++ b/scripts/sh/build_appstore_release.sh
@@ -1180,7 +1180,11 @@ EOF
     fi
 
     if [ -x "${APP_BUNDLE}/Contents/Resources/python3_embed" ]; then
-        sign_with_id "${APP_BUNDLE}/Contents/Resources/python3_embed"
+        codesign --force --sign "${DEVELOPER_ID}" \
+            --entitlements "${OLLAMA_ENTITLEMENTS}" \
+            --options runtime \
+            --timestamp \
+            "${APP_BUNDLE}/Contents/Resources/python3_embed"
     fi
 
     # Copy additional resources


### PR DESCRIPTION
## Summary
- Sign the embedded `python3_embed` helper with sandbox/inherit entitlements for App Store package validation.

## Validation
- `bash scripts/sh/build_appstore_release.sh --skip-notarization --no-bump` succeeded.
- `bash build-scripts/submit_appstore.sh --auto` exported and uploaded successfully.
- App Store upload delivery UUID: `4a5e81a1-8867-4064-8d24-c539daa8c4d0`.
