### PR TITLE
Keep embedded Python helper executable for Developer ID releases

### DIFF
--- a/scripts/sh/build_appstore_release.sh
+++ b/scripts/sh/build_appstore_release.sh
@@ -1180,11 +1180,15 @@ EOF
     fi
 
     if [ -x "${APP_BUNDLE}/Contents/Resources/python3_embed" ]; then
-        codesign --force --sign "${DEVELOPER_ID}" \
-            --entitlements "${OLLAMA_ENTITLEMENTS}" \
-            --options runtime \
-            --timestamp \
-            "${APP_BUNDLE}/Contents/Resources/python3_embed"
+        if [[ "${DEVELOPER_ID}" == "3rd Party Mac Developer Application"* || "${DEVELOPER_ID}" == "Apple Distribution"* ]]; then
+            codesign --force --sign "${DEVELOPER_ID}" \
+                --entitlements "${OLLAMA_ENTITLEMENTS}" \
+                --options runtime \
+                --timestamp \
+                "${APP_BUNDLE}/Contents/Resources/python3_embed"
+        else
+            sign_with_id "${APP_BUNDLE}/Contents/Resources/python3_embed"
+        fi
     fi
 
     # Copy additional resources


### PR DESCRIPTION
## Summary
- Use App Store sandbox/inherit entitlements for `python3_embed` only in App Store signing mode.
- Keep Developer ID direct-distribution builds signed without inherited sandbox entitlements so bundle smoke tests can execute the helper.

## Validation
- `bash -n scripts/sh/build_appstore_release.sh`
