### PR TITLE
Fix full E2E workflow secret checks

### DIFF
--- a/.github/workflows/macos-full-e2e.yml
+++ b/.github/workflows/macos-full-e2e.yml
@@ -10,6 +10,13 @@ jobs:
   full-e2e:
     runs-on: macos-14
     timeout-minutes: 30
+    env:
+      MACOS_CERT_P12_BASE64: ${{ secrets.MACOS_CERT_P12_BASE64 }}
+      MACOS_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
+      KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+      ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
+      ASC_API_KEY_ISSUER: ${{ secrets.ASC_API_KEY_ISSUER }}
+      ASC_API_KEY_BASE64: ${{ secrets.ASC_API_KEY_BASE64 }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -21,11 +28,7 @@ jobs:
           python3 scripts/check_markdown_links.py
 
       - name: Import signing certificate (Developer ID Application)
-        if: ${{ secrets.MACOS_CERT_P12_BASE64 && secrets.MACOS_CERT_PASSWORD && secrets.KEYCHAIN_PASSWORD }}
-        env:
-          MACOS_CERT_P12_BASE64: ${{ secrets.MACOS_CERT_P12_BASE64 }}
-          MACOS_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
-          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        if: ${{ env.MACOS_CERT_P12_BASE64 != '' && env.MACOS_CERT_PASSWORD != '' && env.KEYCHAIN_PASSWORD != '' }}
         run: |
           echo "$MACOS_CERT_P12_BASE64" | base64 --decode > signing.p12
           security create-keychain -p "$KEYCHAIN_PASSWORD" ci.keychain
@@ -141,11 +144,7 @@ jobs:
           retention-days: 7
 
       - name: Notarize & staple on tags
-        if: startsWith(github.ref, 'refs/tags/') && secrets.ASC_API_KEY_ID && secrets.ASC_API_KEY_ISSUER && secrets.ASC_API_KEY_BASE64
-        env:
-          ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
-          ASC_API_KEY_ISSUER: ${{ secrets.ASC_API_KEY_ISSUER }}
-          ASC_API_KEY_BASE64: ${{ secrets.ASC_API_KEY_BASE64 }}
+        if: ${{ startsWith(github.ref, 'refs/tags/') && env.ASC_API_KEY_ID != '' && env.ASC_API_KEY_ISSUER != '' && env.ASC_API_KEY_BASE64 != '' }}
         run: |
           chmod +x scripts/notarize_macos.sh || true
           if [ -f scripts/notarize_macos.sh ]; then


### PR DESCRIPTION
## Summary
- move full E2E secret values through job env so step conditions do not reference secrets directly
- keeps tag notarization and certificate import conditions equivalent

## Validation
- ruby YAML parse for .github/workflows/macos-full-e2e.yml
- git diff --check