### PR TITLE
Use imported signing identity in tag E2E

### DIFF
--- a/.github/workflows/macos-full-e2e.yml
+++ b/.github/workflows/macos-full-e2e.yml
@@ -17,6 +17,7 @@ jobs:
       ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
       ASC_API_KEY_ISSUER: ${{ secrets.ASC_API_KEY_ISSUER }}
       ASC_API_KEY_BASE64: ${{ secrets.ASC_API_KEY_BASE64 }}
+      TEAM_ID: QG85EMCQ75
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -26,6 +27,20 @@ jobs:
           python3 scripts/check_dependency_vulnerabilities.py requirements-pinned.txt
           python3 scripts/generate_python_sbom.py --check
           python3 scripts/check_markdown_links.py
+
+      - name: Export release metadata
+        run: |
+          python3 - <<'PY' >> "$GITHUB_ENV"
+          import os
+          import re
+
+          text = open("pyproject.toml", "r", encoding="utf-8").read()
+          version = re.search(r'^version = "([^"]+)"$', text, re.MULTILINE).group(1)
+
+          print(f"VERSION={version}")
+          print(f"BUILD_NUMBER={version}")
+          print(f"FINAL_DMG={os.environ['GITHUB_WORKSPACE']}/MarcutApp-v{version}-AppStore.dmg")
+          PY
 
       - name: Import signing certificate (Developer ID Application)
         if: ${{ env.MACOS_CERT_P12_BASE64 != '' && env.MACOS_CERT_PASSWORD != '' && env.KEYCHAIN_PASSWORD != '' }}
@@ -37,6 +52,17 @@ jobs:
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" ci.keychain
           security import signing.p12 -k ci.keychain -P "$MACOS_CERT_PASSWORD" -T /usr/bin/codesign
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" ci.keychain
+
+      - name: Select signing identity
+        run: |
+          SIGN_IDENTITY=$(security find-identity -v -p codesigning | sed -n 's/^ *[0-9]*) [A-F0-9]* "\(.*\)"$/\1/p' | head -n 1)
+          if [ -z "$SIGN_IDENTITY" ]; then
+            echo "No valid signing identity available"
+            security find-identity -v -p codesigning
+            exit 1
+          fi
+          echo "CUSTOM_SIGN_IDENTITY=$SIGN_IDENTITY" >> "$GITHUB_ENV"
+          echo "Using signing identity: $SIGN_IDENTITY"
 
       - name: Prepare stub Ollama for packaging
         run: |
@@ -56,9 +82,6 @@ jobs:
         run: swift test --package-path src/swift/MarcutApp
 
       - name: Build App Store DMG (skip notarization here)
-        env:
-          CUSTOM_SIGN_IDENTITY: "${{ secrets.MACOS_SIGN_IDENTITY || 'Developer ID Application: Marc Mandel (QG85EMCQ75)' }}"
-          TEAM_ID: QG85EMCQ75
         run: |
           chmod +x scripts/sh/build_appstore_release.sh
           ./scripts/sh/build_appstore_release.sh --skip-notarization
@@ -144,7 +167,7 @@ jobs:
           retention-days: 7
 
       - name: Notarize & staple on tags
-        if: ${{ startsWith(github.ref, 'refs/tags/') && env.ASC_API_KEY_ID != '' && env.ASC_API_KEY_ISSUER != '' && env.ASC_API_KEY_BASE64 != '' }}
+        if: ${{ startsWith(github.ref, 'refs/tags/') && startsWith(env.CUSTOM_SIGN_IDENTITY, 'Developer ID Application:') && env.ASC_API_KEY_ID != '' && env.ASC_API_KEY_ISSUER != '' && env.ASC_API_KEY_BASE64 != '' }}
         run: |
           chmod +x scripts/notarize_macos.sh || true
           if [ -f scripts/notarize_macos.sh ]; then


### PR DESCRIPTION
## Summary
- export version/build metadata from pyproject for tag E2E release builds
- select the signing identity imported into the CI keychain instead of hard-coding Developer ID
- skip tag notarization unless the imported CI identity is actually Developer ID

## Validation
- ruby YAML parse for .github/workflows/macos-full-e2e.yml
- git diff --check