### PR TITLE
Fall back to Swift DMG when CI signing is unavailable

### DIFF
--- a/.github/workflows/macos-full-e2e.yml
+++ b/.github/workflows/macos-full-e2e.yml
@@ -57,11 +57,13 @@ jobs:
         run: |
           SIGN_IDENTITY=$(security find-identity -v -p codesigning | sed -n 's/^ *[0-9]*) [A-F0-9]* "\(.*\)"$/\1/p' | head -n 1)
           if [ -z "$SIGN_IDENTITY" ]; then
-            echo "No valid signing identity available"
+            echo "No valid signing identity available; using Swift DMG path for CI packaging"
             security find-identity -v -p codesigning
-            exit 1
+            echo "CI_SIGNING_AVAILABLE=false" >> "$GITHUB_ENV"
+            exit 0
           fi
           echo "CUSTOM_SIGN_IDENTITY=$SIGN_IDENTITY" >> "$GITHUB_ENV"
+          echo "CI_SIGNING_AVAILABLE=true" >> "$GITHUB_ENV"
           echo "Using signing identity: $SIGN_IDENTITY"
 
       - name: Prepare stub Ollama for packaging
@@ -81,16 +83,23 @@ jobs:
       - name: Swift unit tests
         run: swift test --package-path src/swift/MarcutApp
 
-      - name: Build App Store DMG (skip notarization here)
+      - name: Build distribution DMG
         run: |
-          chmod +x scripts/sh/build_appstore_release.sh
-          ./scripts/sh/build_appstore_release.sh --skip-notarization
+          if [ "${CI_SIGNING_AVAILABLE:-false}" = "true" ]; then
+            chmod +x scripts/sh/build_appstore_release.sh
+            ./scripts/sh/build_appstore_release.sh --skip-notarization
+          else
+            chmod +x scripts/sh/build_swift_only.sh
+            ./scripts/sh/build_swift_only.sh
+          fi
 
       - name: Verify DMG (artifact checks + embedded spawn + mock redaction)
         run: |
+          DMG=$(ls -1 MarcutApp-v*-AppStore.dmg MarcutApp-Swift-*.dmg 2>/dev/null | head -n 1)
+          test -n "$DMG"
           chmod +x scripts/verify_bundle.sh || true
           if [ -f scripts/verify_bundle.sh ]; then
-            bash scripts/verify_bundle.sh MarcutApp-v*-AppStore.dmg
+            bash scripts/verify_bundle.sh "$DMG"
           else
             echo "scripts/verify_bundle.sh not present in repo; please add it from upload/scripts/"
             exit 1
@@ -116,7 +125,7 @@ jobs:
         env:
           OLLAMA_HOST: http://127.0.0.1:11434
         run: |
-          DMG=$(ls -1 MarcutApp-v*-AppStore.dmg | tail -1)
+          DMG=$(ls -1 MarcutApp-v*-AppStore.dmg MarcutApp-Swift-*.dmg 2>/dev/null | head -n 1)
           echo "Using DMG: $DMG"
           MNT=$(hdiutil attach -nobrowse "$DMG" | awk '{print $3}' | tail -1)
           echo "Mounted at: $MNT"
@@ -140,7 +149,7 @@ jobs:
         env:
           OLLAMA_HOST: http://127.0.0.1:11434
         run: |
-          DMG=$(ls -1 MarcutApp-v*-AppStore.dmg | tail -1)
+          DMG=$(ls -1 MarcutApp-v*-AppStore.dmg MarcutApp-Swift-*.dmg 2>/dev/null | head -n 1)
           MNT=$(hdiutil attach -nobrowse "$DMG" | awk '{print $3}' | tail -1)
           APP_MNT="$MNT/MarcutApp.app"
           DST="$HOME/Applications/MarcutApp.app"
@@ -167,7 +176,7 @@ jobs:
           retention-days: 7
 
       - name: Notarize & staple on tags
-        if: ${{ startsWith(github.ref, 'refs/tags/') && startsWith(env.CUSTOM_SIGN_IDENTITY, 'Developer ID Application:') && env.ASC_API_KEY_ID != '' && env.ASC_API_KEY_ISSUER != '' && env.ASC_API_KEY_BASE64 != '' }}
+        if: ${{ startsWith(github.ref, 'refs/tags/') && env.CI_SIGNING_AVAILABLE == 'true' && startsWith(env.CUSTOM_SIGN_IDENTITY, 'Developer ID Application:') && env.ASC_API_KEY_ID != '' && env.ASC_API_KEY_ISSUER != '' && env.ASC_API_KEY_BASE64 != '' }}
         run: |
           chmod +x scripts/notarize_macos.sh || true
           if [ -f scripts/notarize_macos.sh ]; then


### PR DESCRIPTION
## Summary
- let tag E2E continue with the Swift DMG verification path when CI has no valid codesigning identity
- keep App Store packaging in the workflow when a signing identity is available
- keep tag notarization gated to Developer ID signed artifacts only

## Validation
- ruby YAML parse for .github/workflows/macos-full-e2e.yml
- bash -n scripts/sh/build_appstore_release.sh
- git diff --check