### PR TITLE
Remove stale enhanced flag from tag E2E

### DIFF
--- a/.github/workflows/macos-full-e2e.yml
+++ b/.github/workflows/macos-full-e2e.yml
@@ -141,7 +141,7 @@ jobs:
           p=Path(sys.argv[1]); d=Document(); d.add_paragraph('Email: alice@example.com URL: https://legal.example')
           d.save(p); print('ok')
           PY
-          /bin/bash "$PY" -m marcut.cli redact --in "$INP" --out "$OUTDOC" --report "$OUTJSON" --backend ollama --model llama3.2:1b --enhanced
+          /bin/bash "$PY" -m marcut.cli redact --in "$INP" --out "$OUTDOC" --report "$OUTJSON" --backend ollama --model llama3.2:1b
           test -f "$OUTDOC" && test -f "$OUTJSON"
           hdiutil detach "$MNT"
 
@@ -164,7 +164,7 @@ jobs:
           p=Path(sys.argv[1]); d=Document(); d.add_paragraph('Contact: bob@example.com URL: https://contracts.example')
           d.save(p); print('ok')
           PY
-          /bin/bash "$PY" -m marcut.cli redact --in "$INP" --out "$OUTDOC" --report "$OUTJSON" --backend ollama --model llama3.2:1b --enhanced
+          /bin/bash "$PY" -m marcut.cli redact --in "$INP" --out "$OUTDOC" --report "$OUTJSON" --backend ollama --model llama3.2:1b
           test -f "$OUTDOC" && test -f "$OUTJSON"
           hdiutil detach "$MNT"
 


### PR DESCRIPTION
## Summary
- remove the unsupported --enhanced CLI flag from mounted and installed DMG live redaction checks

## Validation
- ruby YAML parse for .github/workflows/macos-full-e2e.yml
- git diff --check