### PR TITLE
test: add PII detection precision/recall evaluation harness (A1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Python smoke tests (rules-only)
         run: |
-          pytest -q tests/test_rules.py tests/test_rule_filter.py
+          pytest -q tests/test_rules.py tests/test_rule_filter.py tests/test_pii_eval_harness.py
 
       - name: Swift build (compile-only)
         run: |

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -207,6 +207,32 @@ If App Group entitlements are enabled (custom builds), these paths can be mirror
 - The metadata matrix script (`scripts/run_metadata_matrix.py`) auto-generates a minimal DOCX if `sample-files/Sample 123 Consent.docx` is missing; keep real sample files locally for higher-fidelity validation.
 - The build TUI “Run Tests” menu delegates to `run_tests.py`, so the same behaviors apply there.
 
+### PII Detection Accuracy (Precision/Recall) Eval
+Detection-quality regressions are caught by an automated per-entity-type precision/recall
+harness, in addition to the existing manual LLM benchmark tooling:
+
+- **`tests/test_pii_eval_harness.py`** — builds a small synthetic, labeled DOCX corpus at
+  test time (`tests/pii_eval/corpus.py` + `tests/pii_eval/labels.json`; nothing binary is
+  committed) covering EMAIL, PHONE, SSN, CARD, MONEY, DATE, ORG, LOC, and NAME across the
+  document body, a table cell, the header, and the footer. It runs the corpus through the
+  **rules-only** pipeline (`mode="rules"`, no Ollama needed) and asserts per-type
+  precision/recall against regression floors, printing a per-type table. This is the test
+  that runs in CI (see the "smoke" job in `.github/workflows/ci.yml` and the full-suite
+  `pytest -q` job in `.github/workflows/macos-build-verify.yml`).
+- **`tests/pii_eval/run_eval.py`** — standalone runner for the *same* corpus, usable
+  locally to eval the full two-pass LLM pipeline against a real Ollama model (not run in
+  CI: it needs Ollama installed locally and isn't deterministic run-to-run):
+  ```bash
+  ollama serve &
+  ollama pull qwen2.5:14b
+  PYTHONPATH=src/python python3 -m tests.pii_eval.run_eval --mode llm --model qwen2.5:14b
+  ```
+  Run `--mode rules` (the default) to reproduce the CI gate locally without Ollama.
+- **`tests/benchmark/model_benchmark.py`** — pre-existing, broader model speed-vs-accuracy
+  comparison tool (Ollama or GGUF, aggregate precision/recall/F1 against a hand-labeled
+  real document); still the right tool for comparing models/prompts against a realistic
+  document rather than the synthetic per-type corpus above.
+
 ### CLI Testing
 ```bash
 # Test CLI functionality (uses PythonKit directly)

--- a/tests/pii_eval/__init__.py
+++ b/tests/pii_eval/__init__.py
@@ -1,0 +1,1 @@
+# PII detection precision/recall evaluation harness (issue A1).

--- a/tests/pii_eval/corpus.py
+++ b/tests/pii_eval/corpus.py
@@ -1,0 +1,91 @@
+"""
+Synthetic labeled PII corpus for the precision/recall evaluation harness (A1).
+
+Builds a small DOCX fixture *at run time* (never committed as a binary -- CI's
+hygiene job forbids checked-in .docx files) covering each core entity type the
+rules engine can detect -- EMAIL, PHONE, SSN, CARD (credit card), MONEY, DATE,
+ORG, LOC (address), NAME -- spread across the document body, a table cell, the
+header, and the footer.
+
+The gold labels live in `labels.json` alongside this module, not as Python
+literals, so they can be reviewed/updated independently of the generator code.
+Keep `labels.json` and `build_corpus_docx()` below in sync: every entity text
+in the JSON file must appear verbatim in the document this module builds.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List
+
+try:
+    from docx import Document
+    DOCX_AVAILABLE = True
+except Exception:  # pragma: no cover - exercised only in stripped-down environments
+    DOCX_AVAILABLE = False
+
+_LABELS_PATH = Path(__file__).resolve().parent / "labels.json"
+
+
+def load_expected_entities() -> List[Dict[str, str]]:
+    """Load the gold-label entity list from labels.json."""
+    data = json.loads(_LABELS_PATH.read_text(encoding="utf-8"))
+    return data["entities"]
+
+
+def build_corpus_docx(path: str) -> None:
+    """Write the synthetic labeled corpus to `path` as a .docx file.
+
+    Every PII value planted here must match an entry in labels.json exactly
+    (see that file's `text` fields).
+    """
+    if not DOCX_AVAILABLE:
+        raise RuntimeError("python-docx is required to build the PII eval corpus")
+
+    doc = Document()
+
+    # --- Body ---
+    doc.add_paragraph(
+        "This engagement letter is issued to confirm the terms discussed below."
+    )
+    doc.add_paragraph(
+        "Please direct all correspondence to Jane Doe at jane.doe@example.com "
+        "or by phone at (415) 555-0182."
+    )
+    doc.add_paragraph(
+        "The client's SSN on record is 123-45-6789, and the retainer card "
+        "charged ends in 4111-1111-1111-1111."
+    )
+    doc.add_paragraph(
+        "An initial retainer of $12,500.00 is due no later than January 15, 2024."
+    )
+    doc.add_paragraph(
+        "This Agreement is entered into between Acme Redwood Corp. and the "
+        "undersigned client."
+    )
+    doc.add_paragraph(
+        "The subject property is located at 742 Evergreen Terrace, Springfield, "
+        "IL 62704."
+    )
+    doc.add_paragraph("Name:   Sam Jacobs")
+
+    # --- Table ---
+    # Note: cell 0 is deliberately filler (no PII) rather than another NAME
+    # signature line. A signature line placed immediately before an ORG-suffix
+    # line (nothing but capitalized words between them) can get absorbed into
+    # one bogus COMPANY_SUFFIX match, since that regex's inter-token separator
+    # (`\s+`) crosses paragraph/cell newlines -- a pre-existing rules.py
+    # accuracy quirk, out of scope for this harness (see docs/backlog
+    # item A6). Keeping filler here avoids coupling this test to that bug.
+    table = doc.add_table(rows=1, cols=2)
+    table.rows[0].cells[0].text = "Row 1 details:"
+    table.rows[0].cells[1].text = "Vertex Analytics Group LLC"
+
+    # --- Header / footer ---
+    section = doc.sections[0]
+    section.header.paragraphs[0].text = "Name:   Jordan Casey"
+    section.header.add_paragraph("Header contact: jordan.casey@example.com")
+    section.footer.paragraphs[0].text = "Name:   Taylor Brooks"
+
+    doc.save(path)

--- a/tests/pii_eval/labels.json
+++ b/tests/pii_eval/labels.json
@@ -1,0 +1,18 @@
+{
+  "notes": "Gold labels for the synthetic corpus built by tests/pii_eval/corpus.py (issue A1). Each 'text' is the literal substring the rules-only pipeline is expected to redact for that entity -- verified by hand against marcut.pipeline.run_redaction(mode='rules') output. Matching in tests/pii_eval/scoring.py uses bidirectional substring containment (not exact offsets or exact equality), so a harmless boundary trim by a rule regex (e.g. a dropped leading parenthesis on a phone number) does not itself count as a miss.",
+  "entities": [
+    {"label": "EMAIL", "text": "jane.doe@example.com", "location": "body"},
+    {"label": "PHONE", "text": "415) 555-0182", "location": "body"},
+    {"label": "SSN", "text": "123-45-6789", "location": "body"},
+    {"label": "CARD", "text": "4111-1111-1111-1111", "location": "body"},
+    {"label": "MONEY", "text": "12,500.00", "location": "body"},
+    {"label": "DATE", "text": "January 15, 2024", "location": "body"},
+    {"label": "ORG", "text": "Acme Redwood Corp.", "location": "body"},
+    {"label": "LOC", "text": "742 Evergreen Terrace, Springfield, IL 62704", "location": "body"},
+    {"label": "NAME", "text": "Sam Jacobs", "location": "body_signature"},
+    {"label": "ORG", "text": "Vertex Analytics Group LLC", "location": "table"},
+    {"label": "NAME", "text": "Jordan Casey", "location": "header"},
+    {"label": "EMAIL", "text": "jordan.casey@example.com", "location": "header"},
+    {"label": "NAME", "text": "Taylor Brooks", "location": "footer"}
+  ]
+}

--- a/tests/pii_eval/run_eval.py
+++ b/tests/pii_eval/run_eval.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""
+Standalone runner for the PII detection precision/recall harness (A1).
+
+CI only ever exercises `--mode rules` (see tests/test_pii_eval_harness.py and
+the "smoke" job in .github/workflows/ci.yml) because it requires no Ollama
+install and is fully deterministic. This script additionally supports
+`--mode llm`, which runs the *same* labeled corpus through the enhanced
+two-pass LLM pipeline against a real local Ollama model -- useful for
+comparing models/prompts, but intentionally not run in CI (it needs Ollama
+running locally and is not deterministic run-to-run).
+
+Usage:
+    # Rules-only (same thing the CI gate runs; no Ollama needed)
+    PYTHONPATH=src/python python3 -m tests.pii_eval.run_eval --mode rules
+
+    # Full LLM-backed eval against a local Ollama model
+    ollama serve &
+    ollama pull qwen2.5:14b
+    PYTHONPATH=src/python python3 -m tests.pii_eval.run_eval --mode llm --model qwen2.5:14b
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC_PYTHON = REPO_ROOT / "src" / "python"
+if str(SRC_PYTHON) not in sys.path:
+    sys.path.insert(0, str(SRC_PYTHON))
+
+from tests.pii_eval.corpus import build_corpus_docx, load_expected_entities  # noqa: E402
+from tests.pii_eval.scoring import score_entities, format_score_table  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--mode", choices=["rules", "llm"], default="rules")
+    parser.add_argument("--model", default="qwen2.5:14b", help="Ollama model id (--mode llm only)")
+    parser.add_argument("--backend", default="ollama", choices=["ollama", "llama_cpp"])
+    parser.add_argument("--llama-gguf", default="", help="Path to a GGUF file (--backend llama_cpp)")
+    parser.add_argument("--keep-docx", help="Optional path to save the generated corpus .docx for inspection")
+    parser.add_argument("--min-precision", type=float, default=0.85)
+    parser.add_argument("--min-recall", type=float, default=0.85)
+    args = parser.parse_args()
+
+    from marcut import pipeline
+
+    with tempfile.TemporaryDirectory() as tmp:
+        input_path = Path(tmp) / "pii_eval_input.docx"
+        output_path = Path(tmp) / "pii_eval_output.docx"
+        report_path = Path(tmp) / "pii_eval_report.json"
+
+        build_corpus_docx(str(input_path))
+        if args.keep_docx:
+            Path(args.keep_docx).write_bytes(input_path.read_bytes())
+            print(f"Saved corpus document to: {args.keep_docx}")
+
+        mode = "rules" if args.mode == "rules" else "rules_override"
+        print(f"Running pipeline in mode={mode!r} (backend={args.backend if mode != 'rules' else 'n/a'})...")
+        code, _timings = pipeline.run_redaction(
+            str(input_path),
+            str(output_path),
+            str(report_path),
+            mode=mode,
+            model_id=args.model if mode != "rules" else "rules",
+            chunk_tokens=800,
+            overlap=80,
+            temperature=0.1,
+            seed=42,
+            debug=False,
+            backend=args.backend,
+            llama_gguf=args.llama_gguf,
+        )
+        if code != 0:
+            print(f"Pipeline returned non-zero exit code: {code}", file=sys.stderr)
+            return code
+
+        report = json.loads(report_path.read_text(encoding="utf-8"))
+
+    predicted = report.get("spans", [])
+    expected = load_expected_entities()
+    results = score_entities(expected, predicted)
+    print()
+    print(format_score_table(results))
+
+    failures = []
+    for label in sorted({e["label"] for e in expected}):
+        r = results.get(label, {"precision": 0.0, "recall": 0.0})
+        if r["recall"] < args.min_recall:
+            failures.append(f"{label}: recall {r['recall']:.2f} < {args.min_recall}")
+        if r["precision"] < args.min_precision:
+            failures.append(f"{label}: precision {r['precision']:.2f} < {args.min_precision}")
+
+    if failures:
+        print("\nBelow threshold:")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+
+    print("\nAll entity types at or above threshold.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/pii_eval/scoring.py
+++ b/tests/pii_eval/scoring.py
@@ -1,0 +1,120 @@
+"""
+Span scorer for the PII detection precision/recall harness (A1).
+
+Matches expected (gold) entities against predicted spans from the redaction
+audit report by (label, text) using bidirectional substring containment,
+rather than exact character offsets or exact string equality:
+
+- Exact offsets would require hardcoding the synthetic document's linearized
+  character positions by hand (fragile, and it duplicates knowledge that
+  belongs to docx_io.py's part-linearization logic).
+- Exact text equality is too strict: rule regexes occasionally trim a boundary
+  character (e.g. a leading parenthesis on a phone number, or a leading
+  currency symbol on a money span) without that being a real detection miss.
+
+Containment still requires genuine overlap of the identifying content, so an
+actually-missed or mislabeled entity still counts as a miss.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+
+def _texts_overlap(expected: str, predicted: str) -> bool:
+    e = (expected or "").strip()
+    p = (predicted or "").strip()
+    if not e or not p:
+        return False
+    return e in p or p in e
+
+
+def score_entities(
+    expected: List[Dict[str, Any]],
+    predicted: List[Dict[str, Any]],
+) -> Dict[str, Dict[str, float]]:
+    """Greedily match expected entities against predicted spans of the same label.
+
+    Each predicted span is consumed by at most one expected entity, so N
+    identical expected entities require N distinct predicted spans (duplicates
+    are not free matches).
+
+    Returns a dict keyed by label plus an "OVERALL" aggregate row, each mapping
+    to {tp, fp, fn, precision, recall, f1}.
+    """
+    remaining: Dict[str, List[Dict[str, Any]]] = {}
+    for sp in predicted:
+        remaining.setdefault(sp.get("label", ""), []).append(sp)
+
+    counts: Dict[str, Dict[str, int]] = {}
+
+    def bump(label: str, key: str) -> None:
+        counts.setdefault(label, {"tp": 0, "fp": 0, "fn": 0})
+        counts[label][key] += 1
+
+    for exp in expected:
+        label = exp["label"]
+        candidates = remaining.get(label, [])
+        match_idx = None
+        for idx, cand in enumerate(candidates):
+            if _texts_overlap(exp["text"], cand.get("text", "")):
+                match_idx = idx
+                break
+        if match_idx is not None:
+            bump(label, "tp")
+            candidates.pop(match_idx)
+        else:
+            bump(label, "fn")
+
+    for label, candidates in remaining.items():
+        for _ in candidates:
+            bump(label, "fp")
+
+    results: Dict[str, Dict[str, float]] = {}
+    total_tp = total_fp = total_fn = 0
+    for label, c in sorted(counts.items()):
+        tp, fp, fn = c["tp"], c["fp"], c["fn"]
+        total_tp += tp
+        total_fp += fp
+        total_fn += fn
+        precision = tp / (tp + fp) if (tp + fp) else 1.0
+        recall = tp / (tp + fn) if (tp + fn) else 1.0
+        f1 = (2 * precision * recall / (precision + recall)) if (precision + recall) else 0.0
+        results[label] = {
+            "tp": tp, "fp": fp, "fn": fn,
+            "precision": precision, "recall": recall, "f1": f1,
+        }
+
+    overall_precision = total_tp / (total_tp + total_fp) if (total_tp + total_fp) else 1.0
+    overall_recall = total_tp / (total_tp + total_fn) if (total_tp + total_fn) else 1.0
+    overall_f1 = (
+        2 * overall_precision * overall_recall / (overall_precision + overall_recall)
+        if (overall_precision + overall_recall) else 0.0
+    )
+    results["OVERALL"] = {
+        "tp": total_tp, "fp": total_fp, "fn": total_fn,
+        "precision": overall_precision, "recall": overall_recall, "f1": overall_f1,
+    }
+    return results
+
+
+def format_score_table(results: Dict[str, Dict[str, float]]) -> str:
+    """Render a per-label precision/recall/F1 table for console output."""
+    lines = [
+        f"{'Label':<10} {'TP':>4} {'FP':>4} {'FN':>4} {'Precision':>10} {'Recall':>8} {'F1':>6}",
+        "-" * 52,
+    ]
+    for label, r in results.items():
+        if label == "OVERALL":
+            continue
+        lines.append(
+            f"{label:<10} {r['tp']:>4} {r['fp']:>4} {r['fn']:>4} "
+            f"{r['precision']:>10.2f} {r['recall']:>8.2f} {r['f1']:>6.2f}"
+        )
+    lines.append("-" * 52)
+    o = results["OVERALL"]
+    lines.append(
+        f"{'OVERALL':<10} {o['tp']:>4} {o['fp']:>4} {o['fn']:>4} "
+        f"{o['precision']:>10.2f} {o['recall']:>8.2f} {o['f1']:>6.2f}"
+    )
+    return "\n".join(lines)

--- a/tests/test_pii_eval_harness.py
+++ b/tests/test_pii_eval_harness.py
@@ -1,0 +1,83 @@
+"""
+Precision/recall evaluation harness for PII detection (issue A1).
+
+Builds a small synthetic, labeled DOCX corpus at test time (see
+tests/pii_eval/corpus.py and tests/pii_eval/labels.json -- generator code and
+JSON labels only; CI's hygiene job forbids checked-in .docx/.doc/.pdf/.dmg
+files), runs it through the rules-only pipeline (no Ollama required, so this
+runs in every CI job -- see the "smoke" job in .github/workflows/ci.yml), and
+asserts per-entity-type precision/recall against regression floors.
+
+This closes the gap the survey flagged: previously, precision/recall metrics
+existed only in manual, Ollama-dependent tooling (tests/benchmark/model_benchmark.py,
+tests/scripts/score_answer_key_matrix.py) that isn't wired into pytest/CI and
+doesn't break results out per entity type. This module is the automated,
+CI-gated counterpart; see docs/DEVELOPER_GUIDE.md for how to run the same
+corpus through the full LLM-backed pipeline locally via
+tests/pii_eval/run_eval.py.
+"""
+
+import json
+
+import pytest
+
+try:
+    from marcut import pipeline
+    IMPORTS_SUCCESS = True
+except Exception:
+    IMPORTS_SUCCESS = False
+
+from tests.pii_eval.corpus import DOCX_AVAILABLE, build_corpus_docx, load_expected_entities
+from tests.pii_eval.scoring import format_score_table, score_entities
+
+# Regression floors, not aspirational targets. This corpus is small and fully
+# deterministic under rules-only mode (no LLM sampling involved), so today's
+# rules engine clears every entity type at 1.0 precision/recall; the floor
+# below leaves room for legitimate future corpus growth without making the
+# gate flaky, while still catching a real detection regression.
+MIN_PRECISION = 0.85
+MIN_RECALL = 0.85
+
+
+@pytest.mark.skipif(
+    not (DOCX_AVAILABLE and IMPORTS_SUCCESS),
+    reason="python-docx or marcut not available",
+)
+def test_rules_only_precision_recall_per_entity_type(tmp_path):
+    input_path = tmp_path / "pii_eval_input.docx"
+    output_path = tmp_path / "pii_eval_output.docx"
+    report_path = tmp_path / "pii_eval_report.json"
+
+    build_corpus_docx(str(input_path))
+
+    code, _timings = pipeline.run_redaction(
+        str(input_path),
+        str(output_path),
+        str(report_path),
+        mode="rules",
+        model_id="rules",
+        chunk_tokens=800,
+        overlap=80,
+        temperature=0.1,
+        seed=42,
+        debug=False,
+    )
+    assert code == 0
+    assert report_path.exists()
+
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    predicted = report.get("spans", [])
+
+    expected = load_expected_entities()
+    results = score_entities(expected, predicted)
+    print("\n" + format_score_table(results))
+
+    failures = []
+    for label in sorted({e["label"] for e in expected}):
+        r = results.get(label, {"precision": 0.0, "recall": 0.0})
+        if r["recall"] < MIN_RECALL:
+            failures.append(f"{label}: recall {r['recall']:.2f} < {MIN_RECALL}")
+        if r["precision"] < MIN_PRECISION:
+            failures.append(f"{label}: precision {r['precision']:.2f} < {MIN_PRECISION}")
+
+    assert not failures, "Precision/recall regression:\n" + "\n".join(failures)


### PR DESCRIPTION
Closes #36

The survey (feature-complete hardening review 2026-07-05) claimed nothing in `tests/` or `scripts/` measured detection precision/recall, making accuracy changes unfalsifiable. I confirmed this by inspecting `tests/` and `scripts/` — the only existing measurement tooling (`tests/benchmark/model_benchmark.py`, `tests/scripts/score_answer_key_matrix.py`) is manual, Ollama-dependent, and not wired into pytest/CI or broken out per entity type. I added `tests/pii_eval/` (a synthetic, labeled DOCX corpus built at test time via python-docx, plus a span scorer) and `tests/test_pii_eval_harness.py`, which runs the corpus through the rules-only pipeline and asserts per-entity-type precision/recall against regression floors; wired it into the CI smoke job; and documented the local full-LLM eval path (`tests/pii_eval/run_eval.py`) in DEVELOPER_GUIDE.md.

Verification:
- PYTHONPATH=src/python python3 -m pytest -q — 464 passed, 6 skipped
- swift test — not applicable (no Swift files touched)
Independent review: approved.