### PR TITLE
fix: dedupe chunk-boundary entity duplicates, enforce offset invariant (A3)

### DIFF
--- a/src/python/marcut/model_enhanced.py
+++ b/src/python/marcut/model_enhanced.py
@@ -817,6 +817,87 @@ def ollama_validate(
     raise RuntimeError(f"Ollama validation failed after {len(retry_plan)} attempts: {last_error}")
 
 
+def _drop_invalid_entity_offsets(
+    text: str,
+    entities: List["Entity"],
+    warnings: List[Dict[str, Any]],
+) -> List["Entity"]:
+    """Enforce the invariant text[start:end] == entity.text, dropping violations.
+
+    Chunk-relative spans are rebased to document coordinates as soon as each
+    chunk's entities are extracted, so this is defense-in-depth rather than
+    the primary correctness mechanism -- but it guarantees a corrupted span
+    never reaches the rest of the pipeline; violations are dropped and
+    logged instead of silently emitted (coordinates with issue A5's broader
+    bounds/consistency guard at span-application time).
+    """
+    valid: List[Entity] = []
+    for entity in entities:
+        in_bounds = 0 <= entity.start < entity.end <= len(text)
+        if in_bounds and text[entity.start:entity.end] == entity.text:
+            valid.append(entity)
+            continue
+        warnings.append({
+            "code": "LLM_ENTITY_OFFSET_MISMATCH",
+            "message": "Dropped an extracted entity whose offsets did not match its text.",
+            "details": f"label={entity.label} start={entity.start} end={entity.end} text={entity.text!r}",
+        })
+    return valid
+
+
+def _resolve_overlapping_entity(current: "Entity", candidate: "Entity") -> "Entity":
+    """Choose which of two overlapping same-label entities to keep.
+
+    Prefers, in order: a positive redaction decision (fail closed -- if
+    either detection says redact, keep the one that redacts), the longer/
+    more complete span, then higher confidence. Ties keep `current`.
+    """
+    current_key = (bool(current.needs_redaction), current.end - current.start, current.confidence)
+    candidate_key = (bool(candidate.needs_redaction), candidate.end - candidate.start, candidate.confidence)
+    return candidate if candidate_key > current_key else current
+
+
+def _dedupe_chunk_overlap_entities(entities: List["Entity"]) -> List["Entity"]:
+    """Collapse same-label entities that only differ because of chunk overlap.
+
+    `chunker.make_chunks` deliberately overlaps adjacent chunks so a mention
+    near a chunk boundary is never silently dropped. As a side effect, a
+    mention that survives intact in more than one chunk is extracted once
+    per chunk that sees it in full, and a mention straddling the boundary
+    can additionally surface as a truncated fragment alongside the full
+    mention recovered from the neighboring chunk. Both show up as
+    overlapping same-label spans at (nearly) the same location; keep a
+    single, best-scoring entity per overlapping cluster instead of emitting
+    every detection. Separate, non-overlapping repeats of the same text
+    elsewhere in the document are untouched -- only spans that actually
+    overlap are merged.
+    """
+    by_label: Dict[str, List[Entity]] = {}
+    for entity in entities:
+        by_label.setdefault(entity.label, []).append(entity)
+
+    deduped: List[Entity] = []
+    for group in by_label.values():
+        group.sort(key=lambda e: (e.start, e.end))
+        current: Optional[Entity] = None
+        reach = 0
+        for entity in group:
+            if current is None:
+                current = entity
+                reach = entity.end
+            elif entity.start < reach:
+                current = _resolve_overlapping_entity(current, entity)
+                reach = max(reach, entity.end)
+            else:
+                deduped.append(current)
+                current = entity
+                reach = entity.end
+        if current is not None:
+            deduped.append(current)
+
+    return deduped
+
+
 class IntelligentRedactionPipeline:
     """Main pipeline for intelligent entity extraction and validation."""
 
@@ -1197,6 +1278,13 @@ class IntelligentRedactionPipeline:
 
         if tracker:
             tracker.update_phase(ProcessingPhase.LLM_EXTRACTION, 1.0, "AI extraction complete")
+
+        # Chunks overlap by design (see chunker.make_chunks), so a mention
+        # near a chunk boundary can be extracted more than once. Enforce the
+        # offset invariant and collapse same-label overlap-window duplicates
+        # before converting to the output format.
+        all_entities = _drop_invalid_entity_offsets(text, all_entities, warnings)
+        all_entities = _dedupe_chunk_overlap_entities(all_entities)
 
         # Convert to output format
         output_spans = []

--- a/tests/test_model_enhanced.py
+++ b/tests/test_model_enhanced.py
@@ -3,6 +3,7 @@ Unit tests for model_enhanced.py retry behavior.
 """
 
 import json
+import re
 import time
 import requests
 import pytest
@@ -218,3 +219,210 @@ def test_document_context_collects_specific_org_alias_after_formation_clause():
     aliases = ctx.entity_aliases.get("time usa, llc", [])
     assert "TIME" in aliases
     assert "Publisher" not in aliases
+
+
+# --- A3: chunk-boundary entity handling in enhanced extraction ---------------
+#
+# `chunker.make_chunks` deliberately overlaps adjacent chunks so no mention is
+# silently dropped at a chunk boundary. That overlap means the *same* mention
+# can be extracted more than once (identically, from the shared overlap
+# window, or as a full match alongside a truncated fragment when it straddles
+# the boundary). These tests pin down that every such mention is reported
+# exactly once, at correct document offsets, and that the invariant
+# text[start:end] == entity_text is enforced rather than silently violated.
+
+def _patch_no_validation(monkeypatch):
+    """Skip LLM validation so raw extraction output flows straight to spans."""
+    monkeypatch.setattr(model_enhanced, "needs_validation", lambda entity, doc_context: False)
+
+
+def test_chunk_overlap_window_entity_deduplicated_to_one(monkeypatch):
+    """A NAME sitting entirely inside the overlap window shared by two
+    adjacent chunks is visible, in full, to both chunks -- it must still be
+    reported exactly once, at the correct document offsets."""
+    filler = "lorem " * 45  # 270 chars of filler before the name
+    name = "John Smith"
+    middle = " is a witness to this agreement, executed on this day. "
+    suffix = "lorem " * 70
+    text = filler + name + middle + suffix
+    name_start = len(filler)
+    name_end = name_start + len(name)
+
+    chunk1 = {"start": 0, "end": 300, "text": text[0:300]}
+    chunk2 = {"start": 260, "end": len(text), "text": text[260:]}
+    # Sanity-check the fixture: the name must fall entirely inside the
+    # overlap window, i.e. both chunks see it whole.
+    assert chunk2["start"] <= name_start and name_end <= chunk1["end"]
+
+    def fake_extract(model_id, chunk_text, temperature=0.0, seed=42, context=None):
+        return [
+            {"start": m.start(), "end": m.end(), "label": "NAME"}
+            for m in re.finditer(r"\bJohn Smith\b", chunk_text)
+        ]
+
+    monkeypatch.setattr("marcut.model.ollama_extract", fake_extract)
+    _patch_no_validation(monkeypatch)
+
+    pipeline = model_enhanced.IntelligentRedactionPipeline("test-model")
+    warnings = []
+    spans = pipeline.process_document(text, [chunk1, chunk2], warnings=warnings, suppressed=[])
+
+    name_spans = [s for s in spans if s["label"] == "NAME"]
+    assert len(name_spans) == 1
+    sp = name_spans[0]
+    assert (sp["start"], sp["end"]) == (name_start, name_end)
+    assert text[sp["start"]:sp["end"]] == sp["text"] == name
+    assert warnings == []
+
+
+def test_chunk_boundary_straddling_entity_keeps_full_span(monkeypatch):
+    """A NAME that straddles the actual chunk boundary can leave a full
+    mention in one chunk and a truncated fragment in the next, because the
+    fragment's leading tokens fall outside the neighbor's window. The
+    complete mention must win, reported exactly once."""
+    filler = "lorem " * 45
+    name = "John Smith"
+    middle = " is a witness to this agreement, executed on this day. "
+    suffix = "lorem " * 70
+    text = filler + name + middle + suffix
+    name_start = len(filler)
+    name_end = name_start + len(name)
+
+    chunk1 = {"start": 0, "end": 300, "text": text[0:300]}
+    # chunk2 begins mid-name (right after "John "), so it only ever sees
+    # the bare surname "Smith".
+    chunk2_start = name_start + len("John ")
+    chunk2 = {"start": chunk2_start, "end": len(text), "text": text[chunk2_start:]}
+    assert text[chunk2_start:chunk2_start + 5] == "Smith"
+
+    def fake_extract(model_id, chunk_text, temperature=0.0, seed=42, context=None):
+        spans = [
+            {"start": m.start(), "end": m.end(), "label": "NAME"}
+            for m in re.finditer(r"\bJohn Smith\b", chunk_text)
+        ]
+        for m in re.finditer(r"\bSmith\b", chunk_text):
+            if not any(s["start"] <= m.start() and m.end() <= s["end"] for s in spans):
+                spans.append({"start": m.start(), "end": m.end(), "label": "NAME"})
+        return spans
+
+    monkeypatch.setattr("marcut.model.ollama_extract", fake_extract)
+    _patch_no_validation(monkeypatch)
+
+    pipeline = model_enhanced.IntelligentRedactionPipeline("test-model")
+    warnings = []
+    spans = pipeline.process_document(text, [chunk1, chunk2], warnings=warnings, suppressed=[])
+
+    name_spans = [s for s in spans if s["label"] == "NAME"]
+    assert len(name_spans) == 1
+    sp = name_spans[0]
+    assert (sp["start"], sp["end"]) == (name_start, name_end)
+    assert sp["text"] == name
+    assert warnings == []
+
+
+def test_entities_at_document_start_and_end_of_chunks_survive(monkeypatch):
+    """Entities exactly at the leading edge of the first chunk and the
+    trailing edge of the last chunk must round-trip with correct offsets --
+    the edge case where there is no overlap partner on the outer side."""
+    head_name = "Jane Doe"
+    middle = "lorem " * 60
+    tail_name = "Robert Lee"
+    text = head_name + " " + middle + tail_name
+    tail_start = len(text) - len(tail_name)
+
+    chunk1 = {"start": 0, "end": 150, "text": text[0:150]}
+    chunk2 = {"start": 100, "end": 250, "text": text[100:250]}
+    chunk3 = {"start": 200, "end": len(text), "text": text[200:]}
+
+    def fake_extract(model_id, chunk_text, temperature=0.0, seed=42, context=None):
+        spans = []
+        for pattern in (r"\bJane Doe\b", r"\bRobert Lee\b"):
+            for m in re.finditer(pattern, chunk_text):
+                spans.append({"start": m.start(), "end": m.end(), "label": "NAME"})
+        return spans
+
+    monkeypatch.setattr("marcut.model.ollama_extract", fake_extract)
+    _patch_no_validation(monkeypatch)
+
+    pipeline = model_enhanced.IntelligentRedactionPipeline("test-model")
+    spans = pipeline.process_document(text, [chunk1, chunk2, chunk3], warnings=[], suppressed=[])
+
+    name_spans = sorted((s["start"], s["end"], s["text"]) for s in spans if s["label"] == "NAME")
+    assert name_spans == [
+        (0, len(head_name), head_name),
+        (tail_start, len(text), tail_name),
+    ]
+    for start, end, txt in name_spans:
+        assert text[start:end] == txt
+
+
+def test_drop_invalid_entity_offsets_removes_and_logs_mismatches():
+    """The hard invariant text[start:end] == entity.text must hold for every
+    surviving entity; violations are dropped and logged rather than emitted."""
+    text = "Contact John Smith regarding the matter."
+    good = Entity(text="John Smith", label="NAME", start=8, end=18, confidence=0.7, needs_redaction=True)
+    drifted = Entity(text="John Smith", label="NAME", start=9, end=19, confidence=0.7, needs_redaction=True)
+    out_of_bounds = Entity(text="ignored", label="NAME", start=30, end=999, confidence=0.7, needs_redaction=True)
+
+    warnings = []
+    survivors = model_enhanced._drop_invalid_entity_offsets(text, [good, drifted, out_of_bounds], warnings)
+
+    assert survivors == [good]
+    assert len(warnings) == 2
+    assert all(w["code"] == "LLM_ENTITY_OFFSET_MISMATCH" for w in warnings)
+
+
+def test_process_document_drops_out_of_bounds_span_instead_of_corrupting_output(monkeypatch):
+    """An extraction span that lands out of bounds must be dropped and
+    logged, never surfaced as a corrupted entity."""
+    text = "Contact John Smith today please."
+
+    def fake_extract(model_id, chunk_text, temperature=0.0, seed=42, context=None):
+        # An "end" far beyond the chunk (and the document) simulates a
+        # drifted/corrupted span rather than a legitimate extraction.
+        return [{"start": 8, "end": 999999, "label": "NAME"}]
+
+    monkeypatch.setattr("marcut.model.ollama_extract", fake_extract)
+    _patch_no_validation(monkeypatch)
+
+    pipeline = model_enhanced.IntelligentRedactionPipeline("test-model")
+    warnings = []
+    spans = pipeline.process_document(
+        text,
+        [{"start": 0, "end": len(text), "text": text}],
+        warnings=warnings,
+        suppressed=[],
+    )
+
+    assert spans == []
+    assert any(w["code"] == "LLM_ENTITY_OFFSET_MISMATCH" for w in warnings)
+
+
+def test_dedupe_chunk_overlap_entities_prefers_redaction_then_length_then_confidence():
+    """Tie-break contract for overlapping same-label entities: a positive
+    redaction decision wins first (fail closed), then the longer span, then
+    higher confidence."""
+    # needs_redaction=True beats needs_redaction=False even though the
+    # False entity is longer.
+    keep_redacts = Entity(text="Smith", label="NAME", start=10, end=15, confidence=0.7, needs_redaction=True)
+    skip_longer = Entity(text="Mr. Smith", label="NAME", start=6, end=15, confidence=0.7, needs_redaction=False)
+    result = model_enhanced._dedupe_chunk_overlap_entities([skip_longer, keep_redacts])
+    assert result == [keep_redacts]
+
+    # Same redaction decision: longer span wins.
+    short = Entity(text="Smith", label="NAME", start=10, end=15, confidence=0.9, needs_redaction=True)
+    longer = Entity(text="John Smith", label="NAME", start=5, end=15, confidence=0.7, needs_redaction=True)
+    result = model_enhanced._dedupe_chunk_overlap_entities([short, longer])
+    assert result == [longer]
+
+    # Same decision and length: higher confidence wins.
+    low_conf = Entity(text="Smith", label="NAME", start=10, end=15, confidence=0.6, needs_redaction=True)
+    high_conf = Entity(text="Smith", label="NAME", start=10, end=15, confidence=0.9, needs_redaction=True)
+    result = model_enhanced._dedupe_chunk_overlap_entities([low_conf, high_conf])
+    assert result == [high_conf]
+
+    # Non-overlapping repeats of the same label/text elsewhere are untouched.
+    first = Entity(text="Smith", label="NAME", start=0, end=5, confidence=0.7, needs_redaction=True)
+    second = Entity(text="Smith", label="NAME", start=100, end=105, confidence=0.7, needs_redaction=True)
+    result = model_enhanced._dedupe_chunk_overlap_entities([first, second])
+    assert result == [first, second]


### PR DESCRIPTION
Closes #38

The hardening-review survey claimed the chunk-relative-to-document-offset adjustment in `model_enhanced.py` could drop or mis-offset entities straddling the overlap window between adjacent chunks, producing spans where `text[start:end] != entity_text`. I confirmed the risk: because `chunker.make_chunks` overlaps adjacent chunks by design, a mention can be extracted more than once (identically from the shared window, or as a full match alongside a truncated fragment when it straddles the boundary), with nothing enforcing the offset invariant or deduping the results. I added a hard invariant check (`_drop_invalid_entity_offsets`) that drops and logs (`LLM_ENTITY_OFFSET_MISMATCH`) any entity whose offsets don't match its text, and an overlap-aware dedup pass (`_dedupe_chunk_overlap_entities`) that collapses duplicate/overlapping same-label detections per cluster, preferring a positive redaction decision (fail closed), then longer span, then higher confidence.

Verification:
- PYTHONPATH=src/python python3 -m pytest -q — 439 passed, 6 skipped, 2 pre-existing failures unrelated to this change (confirmed identical with staged changes reverted; local docx-save environment issue), plus 2 pre-existing collection errors in unrelated files (Python 3.9 venv vs 3.10+ `X | None` syntax, also confirmed pre-existing). The 15 tests in tests/test_model_enhanced.py, including the 5 new tests added for this fix, all pass.
- swift test — not applicable (Python-only change)
Independent review: approved.

Note: this repo's branch ruleset requires a code-owner approving review, and CODEOWNERS names only the PR-author account as owner — native GitHub self-approval is therefore impossible for this automation. The repo owner has explicitly authorized an admin-bypass merge for this loop, conditioned on independent (Opus) review approval plus fully green required status checks. Both gates were satisfied before this PR was merged.