### PR TITLE
fix: fail closed on partial LLM chunk extraction failure (A4)

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -116,6 +116,23 @@ to keep a required legend or page-numbering header, the table above applies:
 any PII in the retained header/footer is redacted with track changes like
 any other part.
 
+### AI extraction failures fail the run closed
+
+In `enhanced` (and other LLM-using) modes, long documents are split into
+overlapping chunks and each chunk is analyzed by the local model
+independently. If the model extraction for a chunk never succeeds -- after
+its automatic retries -- Marcut does **not** fall back to redacting only
+what the other chunks found. The entire run fails closed: no output DOCX is
+written, and the JSON report is a failure report (`"status": "error"`) with
+`"error_code": "AI_CHUNK_EXTRACTION_INCOMPLETE"` whose `technical_details`
+names the exact document character range(s) that were never analyzed. This
+is deliberate: for a privacy tool, silently shipping a "redacted" document
+that skipped an unanalyzed range would be worse than failing the run --
+retry with a smaller chunk size, a different model, or check that Ollama is
+reachable, then re-run. This is separate from a processing-deadline abort
+(`AI_PROCESSING_TIMEOUT`), which continues to fail the run the same way it
+always has.
+
 ## Troubleshooting
 - "Ollama not installed": The CLI checks for the `ollama` binary in PATH. If your server is running but the binary is missing, install Ollama or fix PATH.
 - Empty/low ORG or NAME detection: Ensure the model is running and selected (e.g., `--model qwen2.5:14b`).

--- a/src/python/marcut/model_enhanced.py
+++ b/src/python/marcut/model_enhanced.py
@@ -898,6 +898,30 @@ def _dedupe_chunk_overlap_entities(entities: List["Entity"]) -> List["Entity"]:
     return deduped
 
 
+class LLMChunkExtractionFailed(RuntimeError):
+    """Raised when the LLM extractor could not analyze one or more chunks.
+
+    Marcut is a privacy tool: if part of the document text was never scanned
+    by the LLM, the run must fail closed rather than silently ship a
+    redacted DOCX that looks complete while some text ranges were never
+    analyzed. ``failures`` lists one entry per chunk that never produced a
+    successful extraction, each with the document-coordinate character range
+    (``start``/``end``) that was left unanalyzed.
+    """
+
+    def __init__(self, failures: List[Dict[str, Any]], total_chunks: int):
+        self.failures = list(failures)
+        self.total_chunks = total_chunks
+        ranges = "; ".join(
+            f"chunk {f['chunk_index'] + 1}/{total_chunks} chars {f['start']}-{f['end']}: {f['error']}"
+            for f in self.failures
+        )
+        super().__init__(
+            f"AI extraction failed for {len(self.failures)} of {total_chunks} chunk(s) "
+            f"after retries; document was not fully analyzed ({ranges})"
+        )
+
+
 class IntelligentRedactionPipeline:
     """Main pipeline for intelligent entity extraction and validation."""
 
@@ -953,6 +977,11 @@ class IntelligentRedactionPipeline:
                 pass
 
         all_entities = []
+        # One entry per chunk whose LLM extraction never succeeded after
+        # retries -- if this is non-empty once every chunk has been
+        # attempted, the run fails closed (see LLMChunkExtractionFailed)
+        # instead of silently completing with unanalyzed text ranges.
+        chunk_failures: List[Dict[str, Any]] = []
 
         tracker = None
         accepts_progress_update = False
@@ -1151,10 +1180,23 @@ class IntelligentRedactionPipeline:
                     tracker.update_phase(ProcessingPhase.LLM_EXTRACTION, chunk_progress, f"Processed chunk {current_chunk}/{total_chunks}")
 
                 if extract_error is not None:
+                    chunk_end = chunk.get("end", chunk_start + len(chunk_text))
                     warnings.append({
                         "code": "LLM_CHUNK_FAILED",
                         "message": f"AI extraction failed for chunk {chunk_idx + 1} after retries.",
-                        "details": str(extract_error)
+                        "details": str(extract_error),
+                        "start": chunk_start,
+                        "end": chunk_end,
+                    })
+                    # Recorded separately from `warnings` (which mixes in
+                    # unrelated warning codes) so the unanalyzed-range check
+                    # below is unambiguous regardless of what else has been
+                    # appended to the shared warnings list.
+                    chunk_failures.append({
+                        "chunk_index": chunk_idx,
+                        "start": chunk_start,
+                        "end": chunk_end,
+                        "error": str(extract_error),
                     })
                     emit_mass_event({
                         "type": "chunk_end",
@@ -1278,6 +1320,18 @@ class IntelligentRedactionPipeline:
 
         if tracker:
             tracker.update_phase(ProcessingPhase.LLM_EXTRACTION, 1.0, "AI extraction complete")
+
+        # Privacy-first fail-closed default: if the LLM extractor never
+        # produced a successful result for one or more chunks (after
+        # retries), do not silently return whatever partial entities were
+        # found elsewhere -- that would ship a redacted document that looks
+        # complete while some text ranges were never analyzed. Raise so the
+        # caller (pipeline.run_redaction) fails the whole run with a report
+        # that discloses exactly which character ranges were skipped. A
+        # deadline/cancellation abort is unaffected: it already raises
+        # ProcessingDeadlineExceeded above and never reaches this point.
+        if chunk_failures:
+            raise LLMChunkExtractionFailed(chunk_failures, total_chunks)
 
         # Chunks overlap by design (see chunker.make_chunks), so a mention
         # near a chunk boundary can be extracted more than once. Enforce the

--- a/src/python/marcut/pipeline.py
+++ b/src/python/marcut/pipeline.py
@@ -95,6 +95,7 @@ from .model_enhanced import (
     apply_llm_overrides_to_rule_spans,
     DocumentContext,
     build_prompt_context,
+    LLMChunkExtractionFailed,
 )
 from .cluster import ClusterTable
 from .confidence import combine, low_conf
@@ -1887,6 +1888,26 @@ def run_redaction(
                         phase_timings["llm_timing"] = llm_timing_detail
                 if debug:
                     print(f"Enhanced AI processing found {len(model_spans)} spans")
+            except LLMChunkExtractionFailed as e:
+                # Privacy-first fail-closed: one or more chunks were never
+                # successfully analyzed by the LLM after retries. Do not
+                # fall through to the generic classification below -- name
+                # this failure mode explicitly and disclose exactly which
+                # document character ranges were never scanned, rather than
+                # a generic "AI processing failed" message.
+                ranges = "; ".join(
+                    f"chars {f['start']}-{f['end']} (chunk {f['chunk_index'] + 1}/{e.total_chunks}): {f['error']}"
+                    for f in e.failures
+                )
+                raise RedactionError(
+                    message="AI could not analyze the entire document; the document was not fully scanned for redaction",
+                    error_code="AI_CHUNK_EXTRACTION_INCOMPLETE",
+                    technical_details=(
+                        f"Model: {model_id}, {len(e.failures)} of {e.total_chunks} chunk(s) failed extraction "
+                        f"after retries. Unanalyzed ranges: {ranges}"
+                    ),
+                    original_error=e
+                )
             except Exception as e:
                 # Check for specific error patterns
                 error_str = str(e).lower()

--- a/tests/test_model_enhanced.py
+++ b/tests/test_model_enhanced.py
@@ -426,3 +426,94 @@ def test_dedupe_chunk_overlap_entities_prefers_redaction_then_length_then_confid
     second = Entity(text="Smith", label="NAME", start=100, end=105, confidence=0.7, needs_redaction=True)
     result = model_enhanced._dedupe_chunk_overlap_entities([first, second])
     assert result == [first, second]
+
+
+# --- A4: fail-open behavior on partial chunk failure -------------------------
+#
+# If the LLM extractor cannot analyze a chunk even after retries, the document
+# text in that chunk's range was never scanned for PII. Marcut is a privacy
+# tool, so this must fail the whole run closed (a clear, disclosed error)
+# rather than silently return whatever the other chunks found while treating
+# the unanalyzed range as if it were clean. A genuine deadline/cancellation
+# abort is a separate, pre-existing code path and must keep surfacing as
+# ProcessingDeadlineExceeded rather than being folded into this new failure.
+
+def test_process_document_fails_closed_when_chunk_extraction_never_succeeds(monkeypatch):
+    """Chunk 2 of 5 fails extraction on every retry attempt: the run must
+    raise LLMChunkExtractionFailed identifying that chunk's exact
+    document-coordinate character range, rather than returning spans from
+    the other four chunks as if the document were fully analyzed."""
+    chunks = [
+        {"start": i * 100, "end": i * 100 + 20, "text": f"chunk {i} content"}
+        for i in range(5)
+    ]
+    calls = {}
+
+    def fake_extract(model_id, chunk_text, temperature=0.0, seed=42, context=None):
+        calls[chunk_text] = calls.get(chunk_text, 0) + 1
+        if chunk_text == "chunk 2 content":
+            raise RuntimeError("simulated Ollama timeout on chunk 2")
+        return []
+
+    monkeypatch.setattr("marcut.model.ollama_extract", fake_extract)
+    monkeypatch.setattr(model_enhanced.time, "sleep", lambda s: None)
+
+    # Sequential (llm_concurrency=1) so every chunk is deterministically
+    # attempted regardless of thread scheduling.
+    pipeline = model_enhanced.IntelligentRedactionPipeline("test-model", llm_concurrency=1)
+    warnings = []
+
+    with pytest.raises(model_enhanced.LLMChunkExtractionFailed) as exc_info:
+        pipeline.process_document(
+            "irrelevant full-document text",
+            chunks,
+            warnings=warnings,
+            suppressed=[],
+        )
+
+    err = exc_info.value
+    assert err.total_chunks == 5
+    assert len(err.failures) == 1
+    failure = err.failures[0]
+    assert failure["chunk_index"] == 2
+    assert failure["start"] == 200
+    assert failure["end"] == 220
+
+    # (a) Processing must continue to every other chunk despite chunk 2's
+    # persistent failure -- the run doesn't stop early; it fails closed only
+    # once the full picture of what wasn't analyzed is known.
+    assert set(calls.keys()) == {c["text"] for c in chunks}
+
+    # (b) The failure is also recorded in `warnings` with its character
+    # range, so a future opt-in "disclose and continue" path would have the
+    # data it needs without re-deriving it.
+    chunk_warnings = [w for w in warnings if w["code"] == "LLM_CHUNK_FAILED"]
+    assert len(chunk_warnings) == 1
+    assert chunk_warnings[0]["start"] == 200
+    assert chunk_warnings[0]["end"] == 220
+
+
+def test_process_document_deadline_exceeded_not_reclassified_as_chunk_failure(monkeypatch):
+    """A deadline that elapses between a chunk's retry attempts must
+    surface as ProcessingDeadlineExceeded -- never reclassified as an
+    ordinary LLMChunkExtractionFailed (and certainly never swallowed as a
+    successful, but partially unanalyzed, result)."""
+
+    def failing_then_deadline_extract(model_id, chunk_text, temperature=0.0, seed=42, context=None):
+        # Deterministically simulate the deadline elapsing while this
+        # (failed) extraction attempt was in flight, rather than relying on
+        # real sleep/timing.
+        monkeypatch.setenv("MARCUT_PROCESSING_DEADLINE_MONOTONIC", str(time.monotonic() - 0.01))
+        raise RuntimeError("transient extraction failure")
+
+    monkeypatch.setattr("marcut.model.ollama_extract", failing_then_deadline_extract)
+
+    pipeline = model_enhanced.IntelligentRedactionPipeline("test-model")
+
+    with pytest.raises(ProcessingDeadlineExceeded):
+        pipeline.process_document(
+            "John Smith",
+            [{"text": "John Smith", "start": 0, "end": 10}],
+            warnings=[],
+            suppressed=[],
+        )

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -757,6 +757,54 @@ class TestLLMDetailTiming:
         assert not output_path.exists()
         assert "AI_PROCESSING_TIMEOUT" in report_path.read_text(encoding="utf-8")
 
+    def test_chunk_extraction_failure_fails_closed_without_writing_output(self, monkeypatch, tmp_path):
+        """A4: when the LLM extractor never succeeds for one or more chunks
+        (after retries), the run must fail closed with a dedicated,
+        disclosed error code identifying the unanalyzed character range --
+        not silently write a redacted document that looks complete."""
+        self._patch_minimal_enhanced_pipeline(monkeypatch)
+        output_path = tmp_path / "output.docx"
+        report_path = tmp_path / "report.json"
+        finalize_called = {"value": False}
+
+        failure = pipeline.LLMChunkExtractionFailed(
+            failures=[{"chunk_index": 1, "start": 250, "end": 500, "error": "Read timed out"}],
+            total_chunks=3,
+        )
+        monkeypatch.setattr(
+            pipeline,
+            "_collect_enhanced_spans",
+            lambda *args, **kwargs: (_ for _ in ()).throw(failure),
+        )
+
+        def fake_finalize(*args, **kwargs):
+            finalize_called["value"] = True
+            output_path.write_bytes(b"partial")
+            return 0
+
+        monkeypatch.setattr(pipeline, "_finalize_and_write", fake_finalize)
+
+        code, _timings = pipeline.run_redaction(
+            str(tmp_path / "input.docx"),
+            str(output_path),
+            str(report_path),
+            mode="rules_override",
+            model_id="llama3.1:8b",
+            chunk_tokens=250,
+            overlap=50,
+            temperature=0.1,
+            seed=42,
+            debug=False,
+            timing=True,
+        )
+
+        assert code == 2
+        assert not finalize_called["value"]
+        assert not output_path.exists()
+        report_payload = report_path.read_text(encoding="utf-8")
+        assert "AI_CHUNK_EXTRACTION_INCOMPLETE" in report_payload
+        assert "250-500" in report_payload
+
 
 class TestTransactionalArtifacts:
     """Test final artifacts are not exposed before the full set is ready."""


### PR DESCRIPTION
Closes #39

**Claim validated:** in `IntelligentRedactionPipeline.process_document` (model_enhanced.py), if LLM extraction for a chunk never succeeded after retries, the run continued and returned whatever spans the *other* chunks found -- the JSON report and output DOCX gave no indication that part of the document was never scanned. For a privacy tool, that's fail-open: the user has no way to know a text range was skipped.

**Fix:** added `LLMChunkExtractionFailed`, raised once every chunk has been attempted if any chunk never produced a successful extraction. `pipeline.run_redaction` catches it and fails the whole run closed with `RedactionError` code `AI_CHUNK_EXTRACTION_INCOMPLETE`, whose `technical_details` names the exact unanalyzed character range(s) -- no output DOCX is written. A genuine deadline/cancellation abort is unaffected: `ProcessingDeadlineExceeded` is raised earlier in the same code path and is never reclassified as this new failure (covered by a dedicated test). Docs updated in `docs/USER_GUIDE.md`.

The optional "disclose and continue" opt-in path described in the issue (an `unprocessed_ranges` report field plus a Swift UI warning, behind deliberate opt-in) was not implemented -- fail-closed-only is the more conservative default for a privacy tool and the ticket marks that path optional.

Verification:
- `python3 -m pytest tests/ -q` -- 476 passed, 6 skipped (skips are pre-existing: a missing sample fixture file and the `RUN_OLLAMA_TESTS` live-Ollama gate, unrelated to this change).
- New tests: `test_process_document_fails_closed_when_chunk_extraction_never_succeeds`, `test_process_document_deadline_exceeded_not_reclassified_as_chunk_failure` (test_model_enhanced.py), `test_chunk_extraction_failure_fails_closed_without_writing_output` (test_pipeline.py).
- Reviewed interactively against the issue's acceptance criteria (fail-closed default, disclosed ranges, deadline non-reclassification, docs, existing test suite green) before merge -- not run through the autonomous afk-loop's independent-review gate.