### PR TITLE
fix: fail closed on partial LLM chunk extraction failure in llama_cpp backend

### DIFF
--- a/src/python/marcut/model_enhanced.py
+++ b/src/python/marcut/model_enhanced.py
@@ -1407,7 +1407,9 @@ def run_enhanced_model(
         if not model_path:
             raise ValueError("model_path required for llama_cpp backend")
         pipeline = LlamaCppRedactionPipeline(model_path, temperature, seed, threads=kwargs.get("threads", 4))
-        return pipeline.process_document(text, chunks, progress_callback=progress_callback)
+        return pipeline.process_document(
+            text, chunks, progress_callback=progress_callback, warnings=warnings
+        )
     else:
         raise ValueError(f"Unsupported backend: {backend}. Use 'ollama' or 'llama_cpp'")
 
@@ -1474,61 +1476,63 @@ class LlamaCppRedactionPipeline:
             raise RuntimeError(f"Error during inference: {e}")
 
     def extract_entities(self, text: str, doc_context: DocumentContext) -> List[Entity]:
-        """Extract entities using local Llama.cpp model."""
-        try:
-            prompt_context = build_prompt_context(doc_context)
-            prompt = build_extraction_prompt(text, prompt_context)
+        """Extract entities using local Llama.cpp model.
 
-            # Generate response locally
-            # Note: We trust the prompt builder to provide the correct JSON structure instruction
-            response_text = self._generate_response(prompt)
+        Does not catch its own exceptions: inference/parsing failures must
+        propagate to the caller (`process_document`'s retry+chunk_failures
+        loop) rather than being swallowed into an empty result, which would
+        silently report a chunk as "scanned, found nothing" when it was
+        never successfully analyzed.
+        """
+        prompt_context = build_prompt_context(doc_context)
+        prompt = build_extraction_prompt(text, prompt_context)
 
-            # Parse JSON response
-            parsed = parse_llm_response(response_text)
+        # Generate response locally
+        # Note: We trust the prompt builder to provide the correct JSON structure instruction
+        response_text = self._generate_response(prompt)
 
-            # Convert parsed dict items to Entity objects
-            entities = []
-            for item in parsed.get("entities", []):
-                entity_text = item.get("text", "")
-                if not entity_text:
-                    continue
+        # Parse JSON response
+        parsed = parse_llm_response(response_text)
 
-                raw_label = item.get("label") or item.get("type") or ""
-                label = _map_label(raw_label)
-                if not label and raw_label:
-                    label = raw_label.strip().upper()
-                if label not in ["NAME", "ORG", "LOC", "DATE", "MONEY", "NUMBER", "EMAIL", "PHONE", "SSN"]:
-                    continue
+        # Convert parsed dict items to Entity objects
+        entities = []
+        for item in parsed.get("entities", []):
+            entity_text = item.get("text", "")
+            if not entity_text:
+                continue
 
-                # Validate candidate (prevent span explosion on garbage)
-                if not _valid_candidate(entity_text, label):
-                    continue
+            raw_label = item.get("label") or item.get("type") or ""
+            label = _map_label(raw_label)
+            if not label and raw_label:
+                label = raw_label.strip().upper()
+            if label not in ["NAME", "ORG", "LOC", "DATE", "MONEY", "NUMBER", "EMAIL", "PHONE", "SSN"]:
+                continue
 
-                # Find all occurrences of the entity text
-                start_search = 0
-                while True:
-                    start = text.find(entity_text, start_search)
-                    if start == -1:
-                        break
+            # Validate candidate (prevent span explosion on garbage)
+            if not _valid_candidate(entity_text, label):
+                continue
 
-                    entity = Entity(
-                        text=entity_text,
-                        label=label,
-                        start=start,
-                        end=start + len(entity_text),
-                        confidence=item.get("confidence", 0.85),
-                        needs_redaction=item.get("needs_redaction", True),
-                        rationale=item.get("rationale"),
-                        source=self.model_path
-                    )
-                    entities.append(entity)
-                    start_search = start + 1
+            # Find all occurrences of the entity text
+            start_search = 0
+            while True:
+                start = text.find(entity_text, start_search)
+                if start == -1:
+                    break
 
-            return entities
+                entity = Entity(
+                    text=entity_text,
+                    label=label,
+                    start=start,
+                    end=start + len(entity_text),
+                    confidence=item.get("confidence", 0.85),
+                    needs_redaction=item.get("needs_redaction", True),
+                    rationale=item.get("rationale"),
+                    source=self.model_path
+                )
+                entities.append(entity)
+                start_search = start + 1
 
-        except Exception as e:
-            print(f"Error in Llama.cpp entity extraction: {e}")
-            return []
+        return entities
 
     def validate_entity(self, entity: Entity, full_text: str, doc_context: DocumentContext) -> Dict:
         """Validate a single entity using local Llama.cpp model."""
@@ -1560,14 +1564,29 @@ class LlamaCppRedactionPipeline:
                 "rationale": f"Validation failed: {str(e)}"
             }
 
-    def process_document(self, text: str, chunks: List[Dict], progress_callback=None) -> List[Dict]:
-        """Process document using the enhanced pipeline with Ollama."""
+    def process_document(
+        self,
+        text: str,
+        chunks: List[Dict],
+        progress_callback=None,
+        warnings: Optional[List[Dict[str, Any]]] = None,
+    ) -> List[Dict]:
+        """Process document using the enhanced pipeline with local llama.cpp inference."""
+        if warnings is None:
+            warnings = []
+
         # Create document context
         doc_context = DocumentContext()
         doc_context.analyze_document(text)
 
         all_entities = []
         total_chunks = len(chunks)
+        # One entry per chunk whose extraction never succeeded after retries --
+        # if non-empty once every chunk has been attempted, the run fails
+        # closed (see LLMChunkExtractionFailed) instead of silently completing
+        # with text ranges that were never analyzed. Mirrors
+        # IntelligentRedactionPipeline.process_document's Ollama-path handling.
+        chunk_failures: List[Dict[str, Any]] = []
 
         # Extract entities from each chunk
         for i, chunk in enumerate(chunks):
@@ -1576,9 +1595,43 @@ class LlamaCppRedactionPipeline:
 
             chunk_text = chunk["text"]
             chunk_start = chunk["start"]
+            chunk_end = chunk.get("end", chunk_start + len(chunk_text))
 
-            # Extract entities from this chunk
-            entities = self.extract_entities(chunk_text, doc_context)
+            # Extract entities from this chunk, with the same retry cadence
+            # as the Ollama path (immediate retry, then one more after a 2s
+            # backoff) before giving up on the chunk.
+            entities: List[Entity] = []
+            extract_error: Optional[Exception] = None
+            for attempt_idx, wait_s in enumerate((0, 2), start=1):
+                try:
+                    check_processing_deadline()
+                    entities = self.extract_entities(chunk_text, doc_context)
+                    check_processing_deadline()
+                    extract_error = None
+                    break
+                except ProcessingDeadlineExceeded:
+                    raise
+                except Exception as e:
+                    extract_error = e
+                    print(f"Extraction attempt {attempt_idx} failed for chunk {i}: {e}")
+                    if wait_s:
+                        time.sleep(wait_s)
+
+            if extract_error is not None:
+                warnings.append({
+                    "code": "LLM_CHUNK_FAILED",
+                    "message": f"AI extraction failed for chunk {i + 1} after retries.",
+                    "details": str(extract_error),
+                    "start": chunk_start,
+                    "end": chunk_end,
+                })
+                chunk_failures.append({
+                    "chunk_index": i,
+                    "start": chunk_start,
+                    "end": chunk_end,
+                    "error": str(extract_error),
+                })
+                continue
 
             # Adjust entity positions to document coordinates
             for entity in entities:
@@ -1588,6 +1641,14 @@ class LlamaCppRedactionPipeline:
                 entity.text = text[entity.start:entity.end]
 
             all_entities.extend(entities)
+
+        # Privacy-first fail-closed default: see LLMChunkExtractionFailed and
+        # IntelligentRedactionPipeline.process_document for the Ollama-path
+        # rationale -- the llama.cpp backend must fail the same way rather
+        # than silently returning partial results as if the document were
+        # fully scanned.
+        if chunk_failures:
+            raise LLMChunkExtractionFailed(chunk_failures, total_chunks)
 
         # Convert entities to span format
         spans = []

--- a/src/python/marcut/pipeline.py
+++ b/src/python/marcut/pipeline.py
@@ -1722,7 +1722,7 @@ def _collect_enhanced_spans(
             threads=threads,
         )
         model_spans = pipeline.process_document(
-            text, chunks, progress_callback=progress_callback
+            text, chunks, progress_callback=progress_callback, warnings=warnings
         )
     else:
         if debug:

--- a/src/python/marcut/pipeline.py
+++ b/src/python/marcut/pipeline.py
@@ -1425,10 +1425,10 @@ def _finalize_and_write(
 
     for sp in spans:
         label = sp["label"]
-        text = sp["text"].strip() # Normalize text for matching
+        entity_text = sp["text"].strip() # Normalize text for matching
 
         if label in ("NAME", "ORG", "BRAND"):
-            eid, score, is_new = ct.link(label, text)
+            eid, score, is_new = ct.link(label, entity_text)
             sp["entity_id"] = eid
             sp["confidence"] = combine(sp.get("confidence", 0.7), agreements=0 if is_new else 1)
         else:
@@ -1436,10 +1436,10 @@ def _finalize_and_write(
             if label not in entity_counters:
                 entity_counters[label] = {}
 
-            if text not in entity_counters[label]:
-                entity_counters[label][text] = len(entity_counters[label]) + 1
+            if entity_text not in entity_counters[label]:
+                entity_counters[label][entity_text] = len(entity_counters[label]) + 1
 
-            seq_id = entity_counters[label][text]
+            seq_id = entity_counters[label][entity_text]
             sp["entity_id"] = f"{label}_{seq_id}"
 
     # Create replacements

--- a/tests/test_model_enhanced.py
+++ b/tests/test_model_enhanced.py
@@ -545,3 +545,136 @@ def test_process_document_deadline_exceeded_not_reclassified_as_chunk_failure(mo
             warnings=[],
             suppressed=[],
         )
+
+
+# --- A4 (llama_cpp parity): fail-closed on partial chunk failure -------------
+#
+# LlamaCppRedactionPipeline.extract_entities() used to catch all of its own
+# exceptions and return [] -- indistinguishable from "the model found nothing
+# in this chunk." Combined with process_document() never threading a
+# `warnings` list through, a genuine inference/parsing failure was completely
+# invisible: no warning, no error, no retry. These tests mirror the Ollama-path
+# A4 fix above (IntelligentRedactionPipeline.process_document) for the
+# llama_cpp backend: retry once, then fail the whole run closed via the same
+# LLMChunkExtractionFailed exception, identifying the unanalyzed range.
+
+def test_llama_cpp_extract_entities_propagates_inference_failure(monkeypatch):
+    """extract_entities() must let a genuine inference/parsing failure
+    propagate rather than silently returning [] -- process_document's retry
+    and chunk_failures bookkeeping depends on seeing the real exception."""
+    pipeline = LlamaCppRedactionPipeline(model_path="/fake/path/model.gguf", temperature=0.1, seed=42)
+    monkeypatch.setattr(
+        pipeline,
+        "_generate_response",
+        lambda prompt, max_tokens=1024: (_ for _ in ()).throw(RuntimeError("Error during inference: boom")),
+    )
+
+    doc_context = DocumentContext()
+    doc_context.analyze_document("John Smith signed the agreement.")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        pipeline.extract_entities("John Smith signed the agreement.", doc_context)
+
+
+def test_llama_cpp_process_document_fails_closed_when_chunk_extraction_never_succeeds(monkeypatch):
+    """Chunk 2 of 5 fails extraction on every retry attempt: the run must
+    raise LLMChunkExtractionFailed identifying that chunk's exact
+    document-coordinate character range, rather than returning spans from
+    the other four chunks as if the document were fully analyzed."""
+    chunks = [
+        {"start": i * 100, "end": i * 100 + 20, "text": f"chunk {i} content"}
+        for i in range(5)
+    ]
+    calls = {}
+
+    def fake_extract_entities(chunk_text, doc_context):
+        calls[chunk_text] = calls.get(chunk_text, 0) + 1
+        if chunk_text == "chunk 2 content":
+            raise RuntimeError("simulated llama.cpp inference failure on chunk 2")
+        return []
+
+    pipeline = LlamaCppRedactionPipeline(model_path="/fake/path/model.gguf", temperature=0.1, seed=42)
+    monkeypatch.setattr(pipeline, "extract_entities", fake_extract_entities)
+    monkeypatch.setattr(model_enhanced.time, "sleep", lambda s: None)
+
+    warnings = []
+    with pytest.raises(model_enhanced.LLMChunkExtractionFailed) as exc_info:
+        pipeline.process_document(
+            "irrelevant full-document text",
+            chunks,
+            warnings=warnings,
+        )
+
+    err = exc_info.value
+    assert err.total_chunks == 5
+    assert len(err.failures) == 1
+    failure = err.failures[0]
+    assert failure["chunk_index"] == 2
+    assert failure["start"] == 200
+    assert failure["end"] == 220
+
+    # Every chunk must still be attempted despite chunk 2's persistent
+    # failure -- the run doesn't stop early; it fails closed only once the
+    # full picture of what wasn't analyzed is known.
+    assert set(calls.keys()) == {c["text"] for c in chunks}
+
+    chunk_warnings = [w for w in warnings if w["code"] == "LLM_CHUNK_FAILED"]
+    assert len(chunk_warnings) == 1
+    assert chunk_warnings[0]["start"] == 200
+    assert chunk_warnings[0]["end"] == 220
+
+
+def test_llama_cpp_process_document_deadline_exceeded_not_reclassified_as_chunk_failure(monkeypatch):
+    """A deadline that elapses between a chunk's retry attempts must
+    surface as ProcessingDeadlineExceeded -- never reclassified as an
+    ordinary LLMChunkExtractionFailed (and certainly never swallowed as a
+    successful, but partially unanalyzed, result)."""
+
+    def failing_then_deadline_extract(chunk_text, doc_context):
+        # Deterministically simulate the deadline elapsing while this
+        # (failed) extraction attempt was in flight, rather than relying on
+        # real sleep/timing.
+        monkeypatch.setenv("MARCUT_PROCESSING_DEADLINE_MONOTONIC", str(time.monotonic() - 0.01))
+        raise RuntimeError("transient extraction failure")
+
+    pipeline = LlamaCppRedactionPipeline(model_path="/fake/path/model.gguf", temperature=0.1, seed=42)
+    monkeypatch.setattr(pipeline, "extract_entities", failing_then_deadline_extract)
+
+    with pytest.raises(ProcessingDeadlineExceeded):
+        pipeline.process_document(
+            "John Smith",
+            [{"text": "John Smith", "start": 0, "end": 10}],
+            warnings=[],
+        )
+
+
+def test_llama_cpp_process_document_succeeds_without_failures(monkeypatch):
+    """Sanity check: a fully successful run (no chunk failures) still
+    returns spans normally, adjusts offsets to document coordinates, and
+    does not raise."""
+    def fake_extract_entities(chunk_text, doc_context):
+        # Entity offsets are chunk-relative; process_document must shift
+        # them into document coordinates using chunk_start.
+        start = chunk_text.index("John Smith")
+        return [Entity(
+            text="John Smith", label="NAME", start=start, end=start + len("John Smith"),
+            confidence=0.85, needs_redaction=True,
+        )]
+
+    pipeline = LlamaCppRedactionPipeline(model_path="/fake/path/model.gguf", temperature=0.1, seed=42)
+    monkeypatch.setattr(pipeline, "extract_entities", fake_extract_entities)
+
+    text = "Preamble. John Smith signed."
+    chunk_start = len("Preamble. ")
+    warnings = []
+    spans = pipeline.process_document(
+        text,
+        [{"start": chunk_start, "end": len(text), "text": text[chunk_start:]}],
+        warnings=warnings,
+    )
+
+    assert len(spans) == 1
+    assert spans[0]["start"] == chunk_start
+    assert spans[0]["text"] == "John Smith"
+    assert text[spans[0]["start"]:spans[0]["end"]] == "John Smith"
+    assert warnings == []

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -917,12 +917,14 @@ class TestLLMDetailTiming:
                 captured["seed"] = seed
                 captured["threads"] = threads
 
-            def process_document(self, text, chunks, progress_callback=None):
+            def process_document(self, text, chunks, progress_callback=None, warnings=None):
                 captured["chunks"] = chunks
+                captured["warnings"] = warnings
                 return [{"start": 0, "end": 10, "label": "NAME", "text": "John Smith"}]
 
         monkeypatch.setattr(pipeline, "LlamaCppRedactionPipeline", FakeLlamaPipeline)
 
+        run_warnings = []
         spans = pipeline._collect_enhanced_spans(
             "John Smith",
             model_id="ignored-model",
@@ -935,6 +937,7 @@ class TestLLMDetailTiming:
             backend="llama_cpp",
             llama_gguf="/models/local.gguf",
             threads=8,
+            warnings=run_warnings,
         )
 
         assert spans[0]["text"] == "John Smith"
@@ -942,6 +945,7 @@ class TestLLMDetailTiming:
         assert captured["temperature"] == 0.4
         assert captured["seed"] == 789
         assert captured["threads"] == 8
+        assert captured["warnings"] is run_warnings
 
     def test_processing_deadline_failure_does_not_write_output_docx(self, monkeypatch, tmp_path):
         self._patch_minimal_enhanced_pipeline(monkeypatch)
@@ -1030,6 +1034,48 @@ class TestLLMDetailTiming:
         report_payload = report_path.read_text(encoding="utf-8")
         assert "AI_CHUNK_EXTRACTION_INCOMPLETE" in report_payload
         assert "250-500" in report_payload
+
+    def test_llama_cpp_chunk_extraction_failure_fails_closed_end_to_end(self, monkeypatch, tmp_path):
+        """A4 parity: the llama_cpp backend must fail closed the same way the
+        Ollama backend does. Unlike the test above (which mocks
+        _collect_enhanced_spans directly), this exercises the real
+        LlamaCppRedactionPipeline.process_document retry/fail-closed logic
+        through the real _collect_enhanced_spans dispatch, only stubbing the
+        model inference call itself -- proving the wiring from the llama_cpp
+        pipeline through to run_redaction's error handling actually works,
+        not just that run_redaction reacts correctly to the exception type."""
+        from marcut import model_enhanced
+
+        self._patch_minimal_enhanced_pipeline(monkeypatch)
+        monkeypatch.setattr(model_enhanced.time, "sleep", lambda s: None)
+
+        def always_fails(self, text, doc_context):
+            raise RuntimeError("simulated llama.cpp inference failure")
+
+        monkeypatch.setattr(pipeline.LlamaCppRedactionPipeline, "extract_entities", always_fails)
+
+        output_path = tmp_path / "output.docx"
+        report_path = tmp_path / "report.json"
+
+        code, _timings = pipeline.run_redaction(
+            str(tmp_path / "input.docx"),
+            str(output_path),
+            str(report_path),
+            mode="rules_override",
+            model_id="ignored-model",
+            chunk_tokens=250,
+            overlap=50,
+            temperature=0.1,
+            seed=42,
+            debug=False,
+            backend="llama_cpp",
+            llama_gguf="/fake/path/model.gguf",
+        )
+
+        assert code == 2
+        assert not output_path.exists()
+        report_payload = report_path.read_text(encoding="utf-8")
+        assert "AI_CHUNK_EXTRACTION_INCOMPLETE" in report_payload
 
 
 class TestTransactionalArtifacts:


### PR DESCRIPTION
## Summary
- `LlamaCppRedactionPipeline.extract_entities()` caught all of its own exceptions and returned `[]` — indistinguishable from "the model found nothing," with no warning recorded anywhere and no retry.
- `process_document()` never threaded a `warnings` list through at all, so a genuine inference/parsing failure on the `--backend llama_cpp` / GGUF path was completely invisible; the run would still complete as if the whole document had been scanned.
- Mirrors the fail-closed pattern already shipped for the Ollama path (#58, `LLMChunkExtractionFailed` / `chunk_failures`): retry once, then raise `LLMChunkExtractionFailed` so `run_redaction` fails the whole run closed with `AI_CHUNK_EXTRACTION_INCOMPLETE` and the exact unanalyzed character range.
- Also includes one unrelated, pre-existing uncommitted fix that was already sitting in the working tree (separate commit): renames a local `text` variable in `_finalize_and_write` that was shadowing the function's own `text` parameter.

Refs #39 — the original A4 fix only covered `IntelligentRedactionPipeline` (Ollama); this closes the same gap for the second backend, which the issue's original "Claim" didn't cover.

## Test plan
- [x] `PYTHONPATH=src/python python3 -m pytest -q` — 500 passed, 6 skipped
- [x] New unit tests in `tests/test_model_enhanced.py`: fail-closed on persistent chunk failure, deadline-exceeded not reclassified as a chunk failure, `extract_entities()` propagates instead of swallowing, happy-path sanity check
- [x] New end-to-end integration test in `tests/test_pipeline.py` exercising the real `LlamaCppRedactionPipeline` → `_collect_enhanced_spans` → `run_redaction` wiring (not just a mocked exception)

🤖 Generated with [Claude Code](https://claude.com/claude-code)