### PR TITLE
fix: perturb seed on Ollama extraction retries so an empty response can't repeat

### DIFF
--- a/src/python/marcut/model.py
+++ b/src/python/marcut/model.py
@@ -722,7 +722,7 @@ def ollama_extract(
     except (TypeError, ValueError):
         num_predict = 2048
 
-    def _request(prompt: str, format_value) -> str:
+    def _request(prompt: str, format_value, *, seed_override: Optional[int] = None) -> str:
         check_processing_deadline()
         if cancel_event is not None and cancel_event.is_set():
             raise ProcessingDeadlineExceeded("Processing cancelled")
@@ -734,7 +734,7 @@ def ollama_extract(
             "think": False,   # Disable thinking mode for Qwen 3.5 and similar models
             "options": {
                 "temperature": max(temperature, 0.1),
-                "seed": seed,
+                "seed": seed if seed_override is None else seed_override,
                 "num_ctx": 12288,
                 "num_predict": num_predict,
                 "top_p": 0.9
@@ -868,6 +868,25 @@ def ollama_extract(
         )
         response_text = ""
 
+    if not response_text.strip():
+        # An empty completion is a distinct failure mode from "present but
+        # malformed" JSON: Ollama's sampling is otherwise deterministic for a
+        # fixed seed, so simply retrying the identical request (or even a
+        # differently-worded correction prompt at the same seed) reproduces
+        # the same empty output. Perturb the seed for one direct retry of the
+        # original request before falling through to self-correction below,
+        # so the retry actually has a chance to sample something different.
+        _log_app_event("Ollama returned an empty response; retrying once with a perturbed seed.")
+        try:
+            response_text = _request(base_prompt, schema_format, seed_override=seed + 1)
+        except (
+            requests.exceptions.HTTPError,
+            requests.exceptions.RequestException,
+            requests.exceptions.ConnectionError,
+            OllamaStreamIncompleteError,
+        ):
+            response_text = ""
+
     try:
         parsed = parse_llm_response(response_text)
     except json.JSONDecodeError as first_error:
@@ -890,7 +909,10 @@ Your invalid response was:
 
 Please correct your response. Return ONLY the valid JSON object that adheres to the schema. Do not include any other text or explanations.
 """
-        corrected_text = _request(correction_prompt, "json")
+        # seed + 2, not + 1: if the empty-response retry above already tried
+        # seed + 1 and still came back empty, reusing it here would repeat
+        # the same failure again -- use a third distinct seed.
+        corrected_text = _request(correction_prompt, "json", seed_override=seed + 2)
         try:
             parsed = parse_llm_response(corrected_text)
         except json.JSONDecodeError as final_error:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -635,6 +635,74 @@ class TestOllamaDiagnostics:
         spans = ollama_extract("mock-model", "Contact Jane Doe for details.", temperature=0.0)
         assert any(s["label"] == "NAME" for s in spans)
 
+    def test_empty_response_retried_with_perturbed_seed_before_self_correction(self, monkeypatch):
+        """Regression for the E2E failure streak (2026-07-10 through 07-14):
+        an empty completion (not just malformed JSON) must be retried with a
+        DIFFERENT seed, not the self-correction prompt at the identical seed --
+        Ollama's sampling is otherwise deterministic for a fixed seed, so a
+        naive retry would just reproduce the same empty output forever. Only
+        two total requests should fire: the perturbed-seed retry succeeds
+        directly, so the self-correction path (a third request) must never
+        be reached."""
+
+        class MockResponse:
+            def __init__(self, response_text):
+                self.response_text = response_text
+
+            def raise_for_status(self):
+                return None
+
+            def json(self):
+                return {"response": self.response_text}
+
+        seeds_seen = []
+        responses = iter([
+            MockResponse(""),
+            MockResponse('{"entities": [{"text": "Jane Doe", "type": "NAME"}]}'),
+        ])
+
+        def fake_post(*args, **kwargs):
+            seeds_seen.append(kwargs["json"]["options"]["seed"])
+            return next(responses)
+
+        monkeypatch.delenv("OLLAMA_HOST", raising=False)
+        monkeypatch.setattr(model_module.requests, "post", fake_post)
+
+        spans = ollama_extract("mock-model", "Contact Jane Doe for details.", temperature=0.0, seed=42)
+        assert any(s["label"] == "NAME" for s in spans)
+        assert seeds_seen == [42, 43]
+
+    def test_empty_response_still_empty_after_retry_falls_through_to_self_correction(self, monkeypatch):
+        """If the perturbed-seed retry is ALSO empty, today's existing
+        self-correction/fail-closed behavior must still apply -- this fix
+        adds one extra chance to recover, it does not weaken the eventual
+        RuntimeError guarantee when the model genuinely cannot produce output."""
+
+        class MockResponse:
+            def __init__(self, response_text):
+                self.response_text = response_text
+
+            def raise_for_status(self):
+                return None
+
+            def json(self):
+                return {"response": self.response_text}
+
+        responses = iter([
+            MockResponse(""),
+            MockResponse(""),
+            MockResponse(""),
+        ])
+
+        def fake_post(*args, **kwargs):
+            return next(responses)
+
+        monkeypatch.delenv("OLLAMA_HOST", raising=False)
+        monkeypatch.setattr(model_module.requests, "post", fake_post)
+
+        with pytest.raises(RuntimeError, match="not valid JSON after self-correction"):
+            ollama_extract("mock-model", "Contact Jane Doe for details.", temperature=0.0, seed=42)
+
 
 class TestIsGenericTerm:
     """Test generic term detection."""


### PR DESCRIPTION
Closes #61

The nightly/tag "macOS Full E2E" workflow failed 5 scheduled runs in a row (07-10 through 07-14). Root cause: `ollama_extract()`'s self-correction retry reused the identical seed as the original request, so when the CI model (`llama3.2:1b`) returned a genuinely empty completion, the retry reproduced the same empty output regardless of prompt/format — Ollama's sampling is otherwise deterministic for a fixed seed. This was masked before #39/A4's fail-closed fix landed (a chunk failure used to fall open silently).

Fix: perturb the seed on a new pre-self-correction empty-response retry (`seed + 1`), and on the existing self-correction retry (`seed + 2`, so it doesn't reuse the same perturbed seed if the first retry was also empty). The eventual fail-closed `RuntimeError` guarantee is unchanged if the model is still empty after both retries.

Verification:
- PYTHONPATH=src/python python3 -m pytest -q — 555 passed, 6 skipped (2 new regression tests)
- Independent review: approved (verified seed perturbation is real via captured request kwargs, confirmed fail-closed guarantee still holds via a 3-empty-responses test, confirmed exception handling doesn't swallow ProcessingDeadlineExceeded)

Note: this repo's branch ruleset requires a code-owner approving review, and CODEOWNERS names only the PR-author account as owner — native GitHub self-approval is therefore impossible for this automation. The repo owner has explicitly authorized an admin-bypass merge for this loop, conditioned on independent (Opus) review approval plus fully green required status checks. Both gates were satisfied before this PR was merged.