### PR TITLE
fix: self-heal stale python_site staging copy in release builds

### DIFF
--- a/scripts/sh/build_appstore_release.sh
+++ b/scripts/sh/build_appstore_release.sh
@@ -398,6 +398,28 @@ validate_resource_bundle_runtimes() {
     fi
 }
 
+sync_python_repo_into_site() {
+    # The python_site/marcut staging copy is local, gitignored build output --
+    # setup_beeware_framework.sh populates it once, but nothing keeps it in
+    # sync with src/python/marcut on every source edit. Re-copying it here
+    # (cheap: source files only, not the Python.framework/pip payload) makes
+    # verify_python_repo_sync below a self-healing step instead of a hard
+    # stop that sends the developer off to re-run the full framework setup
+    # for a one-line source change.
+    local repo_root="$1"
+    local source_root="$2"
+    local repo_pkg="${repo_root}"
+
+    if [ -d "${repo_root}/marcut" ]; then
+        repo_pkg="${repo_root}/marcut"
+    fi
+
+    if [ -d "${repo_pkg}" ] && [ -d "${source_root}" ]; then
+        rm -rf "${source_root}/marcut"
+        cp -R "${repo_pkg}" "${source_root}/marcut"
+    fi
+}
+
 verify_python_repo_sync() {
     local repo_root="$1"
     local source_root="$2"
@@ -1095,6 +1117,7 @@ EOF
     log_step "Installing python_site dependencies..."
     cleanup_path "${APP_BUNDLE}/Contents/Resources/python_site"
     if [ -n "$SWIFT_PYTHON_SITE_SOURCE" ] && [ -d "${SWIFT_PYTHON_SITE_SOURCE}" ]; then
+        sync_python_repo_into_site "${PYTHON_SITE_REPO_SOURCE}" "${SWIFT_PYTHON_SITE_SOURCE}"
         verify_python_repo_sync "${PYTHON_SITE_REPO_SOURCE}" "${SWIFT_PYTHON_SITE_SOURCE}"
         cp -R "${SWIFT_PYTHON_SITE_SOURCE}" "${APP_BUNDLE}/Contents/Resources/python_site"
         log_success "python_site installed ($(du -sh "${APP_BUNDLE}/Contents/Resources/python_site" | cut -f1))"

--- a/scripts/sh/build_swift_only.sh
+++ b/scripts/sh/build_swift_only.sh
@@ -235,6 +235,28 @@ validate_resource_bundle_runtimes() {
     fi
 }
 
+sync_python_repo_into_site() {
+    # The python_site/marcut staging copy is local, gitignored build output --
+    # setup_beeware_framework.sh populates it once, but nothing keeps it in
+    # sync with src/python/marcut on every source edit. Re-copying it here
+    # (cheap: source files only, not the Python.framework/pip payload) makes
+    # verify_python_repo_sync below a self-healing step instead of a hard
+    # stop that sends the developer off to re-run the full framework setup
+    # for a one-line source change.
+    local repo_root="$1"
+    local source_root="$2"
+    local repo_pkg="${repo_root}"
+
+    if [ -d "${repo_root}/marcut" ]; then
+        repo_pkg="${repo_root}/marcut"
+    fi
+
+    if [ -d "${repo_pkg}" ] && [ -d "${source_root}" ]; then
+        rm -rf "${source_root}/marcut"
+        cp -R "${repo_pkg}" "${source_root}/marcut"
+    fi
+}
+
 verify_python_repo_sync() {
     local repo_root="$1"
     local source_root="$2"
@@ -569,6 +591,7 @@ step_assemble_bundle() {
     log_step "Embedding Python runtime"
     rsync -a --delete "${PYTHON_FRAMEWORK_SOURCE}" "${APP_BUNDLE}/Contents/Frameworks/"
     mkdir -p "${APP_BUNDLE}/Contents/Resources/python_site"
+    sync_python_repo_into_site "${PYTHON_SITE_REPO_SOURCE}" "${PYTHON_SITE_SOURCE}"
     verify_python_repo_sync "${PYTHON_SITE_REPO_SOURCE}" "${PYTHON_SITE_SOURCE}"
     rsync -a --delete "${PYTHON_SITE_SOURCE}/" "${APP_BUNDLE}/Contents/Resources/python_site/"
     verify_python_site_source_sync "${PYTHON_SITE_SOURCE}" "${APP_BUNDLE}/Contents/Resources/python_site"


### PR DESCRIPTION
## Summary
- The gitignored `python_site/marcut` build-time staging copy used by `scripts/sh/build_appstore_release.sh` and `scripts/sh/build_swift_only.sh` could silently drift from `src/python/marcut`, causing confusing failures late in the release build (at the existing verify step) instead of a clear, early signal.
- Adds an auto-sync step before the existing verify step in both scripts so the staging copy is refreshed from source before it's checked, self-healing the drift instead of failing on it.

## Test plan
- [x] Deliberately staled the `python_site/marcut` copy and confirmed the new auto-sync step self-heals it before the verify step runs
- [x] Confirmed the existing verify step still passes after auto-sync
- [x] `bash -n` syntax-checked both `scripts/sh/build_appstore_release.sh` and `scripts/sh/build_swift_only.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)