### PR TITLE
fix: don't demand notarization-skip override for App Store builds

### DIFF
--- a/scripts/sh/build_appstore_release.sh
+++ b/scripts/sh/build_appstore_release.sh
@@ -1730,7 +1730,12 @@ final_validation() {
     hdiutil verify "${FINAL_DMG}"
 
     if [ "${SKIP_NOTARIZATION:-false}" = "true" ]; then
-        if [ "${MARCUT_ALLOW_NOTARIZATION_SKIP:-}" = "1" ]; then
+        if [ "${APPSTORE_IDENTITY_DETECTED:-false}" = "true" ]; then
+            # App Store builds are structurally exempt from notarization (App
+            # Review substitutes for it), so this isn't the unsafe skip the
+            # override below guards against -- don't demand it here.
+            log_warning "Notarization validation skipped (App Store identity; notarization is not applicable for App Store submissions)"
+        elif [ "${MARCUT_ALLOW_NOTARIZATION_SKIP:-}" = "1" ]; then
             log_warning "Notarization validation skipped (SKIP_NOTARIZATION=true; MARCUT_ALLOW_NOTARIZATION_SKIP=1)"
         else
             log_error "Refusing to skip notarization validation without MARCUT_ALLOW_NOTARIZATION_SKIP=1"
@@ -1770,6 +1775,7 @@ clean_app_logs() {
 main() {
     # Parse command line arguments
     SKIP_NOTARIZATION=false
+    APPSTORE_IDENTITY_DETECTED=false
     for arg in "$@"; do
         case $arg in
             --skip-notarization)
@@ -1817,6 +1823,11 @@ main() {
             log_warning "Skipping notarization for App Store identity."
             log_warning "Use scripts/sh/build_devid_release.sh for direct distribution."
             SKIP_NOTARIZATION=true
+            # Distinguishes this structural, App-Store-exempt skip from an
+            # explicit/unsafe direct-distribution skip, so final_validation
+            # doesn't demand MARCUT_ALLOW_NOTARIZATION_SKIP=1 for a build
+            # that was never notarization-eligible in the first place.
+            APPSTORE_IDENTITY_DETECTED=true
         fi
     fi
 


### PR DESCRIPTION
## Summary
- `final_validation()` in `scripts/sh/build_appstore_release.sh` required `MARCUT_ALLOW_NOTARIZATION_SKIP=1` whenever `SKIP_NOTARIZATION=true`, but `main()` unconditionally forces `SKIP_NOTARIZATION=true` for any non-Developer-ID (App Store) signing identity, since App Store builds are structurally exempt from notarization (App Review substitutes for it).
- Result: running `bash scripts/sh/build_appstore_release.sh` standalone for an App Store archive — the documented way to build one — always failed at the final self-check with "Refusing to skip notarization validation without MARCUT_ALLOW_NOTARIZATION_SKIP=1", even though the archive, DMG, and entitlements were all correct.
- Fix: track the App-Store-identity case with its own `APPSTORE_IDENTITY_DETECTED` flag, so the override is only demanded for an actual unsafe direct-distribution skip (e.g. `--skip-notarization` passed to a Developer ID build). `scripts/sh/build_devid_release.sh`'s own internal call (which sets `MARCUT_ALLOW_NOTARIZATION_SKIP=1` itself) is unaffected either way.

## Test plan
- [x] `bash -n scripts/sh/build_appstore_release.sh` and `bash -n scripts/sh/build_devid_release.sh` — syntax OK
- [x] Reproduced the bug: `bash scripts/sh/build_appstore_release.sh --no-bump` (no env override) built and signed everything correctly, then failed non-zero at `final_validation`
- [x] Confirmed the fix: same command, same identity, now logs "Notarization validation skipped (App Store identity; notarization is not applicable for App Store submissions)" and reaches `Build Complete! 🎉` / `SUCCESS`
- [x] Confirmed the safety case is preserved by inspection: `APPSTORE_IDENTITY_DETECTED` is only set inside the `DEVELOPER_ID != "Developer ID Application"*` branch, so a Developer ID build run with `--skip-notarization` still requires the explicit override

🤖 Generated with [Claude Code](https://claude.com/claude-code)